### PR TITLE
Add exceptions to the language

### DIFF
--- a/example/BFS-clear.sw
+++ b/example/BFS-clear.sw
@@ -14,11 +14,7 @@ def gotoX : int -> cmd () = \tgt.
     (if (cur < tgt)
        {turn east}
        {turn west};
-     move;
-     new <- getX;
-     if (new == cur)
-       {turn south; move}
-       {};
+     try move {turn south; move};
      gotoX tgt
     )
 end;
@@ -29,23 +25,21 @@ def gotoY : int -> cmd () = \tgt.
     (if (cur < tgt)
        {turn north}
        {turn south};
-     move;
-     new <- getY;
-     if (new == cur)
-       {turn east; move}
-       {};
+     try move {turn east; move};
      gotoY tgt
     )
 end;
 def goto : int -> int -> cmd () = \x. \y. gotoX x; gotoY y; gotoX x; gotoY y end;
 def spawnfwd : cmd () -> cmd () = \c.
-   move;
-   b <- isHere "tree";
-   if b
-     { build "s" c; return () }
-     {};
-   turn back;
-   move
+   try {
+     move;
+     b <- isHere "tree";
+     if b
+       { build "s" c; return () }
+       {};
+     turn back;
+     move
+   } { turn back }
 end;
 def clear : cmd () =
   grab;

--- a/src/Swarm/Game/CEK.hs
+++ b/src/Swarm/Game/CEK.hs
@@ -77,29 +77,12 @@ import qualified Data.Map              as M
 import           Data.Text             (Text)
 import           Witch                 (from)
 
+import           Swarm.Game.Exception
 import           Swarm.Game.Value
 import           Swarm.Language.Pretty
 import           Swarm.Language.Syntax
 import           Swarm.Language.Types
 import           Swarm.Util
-
-------------------------------------------------------------
--- Exceptions
-------------------------------------------------------------
-
-data Exn
-    -- | Something went very wrong.  This is a bug in Swarm and cannot
-    --   be caught by a @try@ block (but at least it will not crash
-    --   the entire UI).
-  = Fatal Text
-
-    -- | A command failed in some way (/e.g./ a 'Move' command could
-    --   not move, or a 'Grab' command found nothing to grab, /etc./).
-  | CmdFailed Const Text
-
-    -- | The user program explicitly called 'Raise'.
-  | User Text
-  deriving (Eq, Show)
 
 ------------------------------------------------------------
 -- Frames and continuations

--- a/src/Swarm/Game/Exception.hs
+++ b/src/Swarm/Game/Exception.hs
@@ -1,0 +1,43 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Swarm.Game.CEK
+-- Copyright   :  Brent Yorgey
+-- Maintainer  :  byorgey@gmail.com
+--
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Runtime exceptions for the Swarm language interpreter.
+--
+-----------------------------------------------------------------------------
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Swarm.Game.Exception where
+
+import           Data.Text             (Text)
+import qualified Data.Text             as T
+
+import           Swarm.Language.Pretty (prettyText)
+import           Swarm.Language.Syntax
+
+data Exn
+    -- | Something went very wrong.  This is a bug in Swarm and cannot
+    --   be caught by a @try@ block (but at least it will not crash
+    --   the entire UI).
+  = Fatal Text
+
+    -- | A command failed in some way (/e.g./ a 'Move' command could
+    --   not move, or a 'Grab' command found nothing to grab, /etc./).
+  | CmdFailed Const Text
+
+    -- | The user program explicitly called 'Raise'.
+  | User Text
+  deriving (Eq, Show)
+
+formatExn :: Exn -> Text
+formatExn (Fatal t) = T.unlines
+  [ T.append "fatal error: " t
+  , "Please report this as a bug at https://github.com/byorgey/swarm/issues ."
+  ]
+formatExn (CmdFailed c t) = T.concat [prettyText c, ": ", t]
+formatExn (User t)        = T.concat ["user exception: ", t]

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -21,7 +21,7 @@ module Swarm.Game.Robot
     -- ** Lenses
   , robotEntity, robotName, robotDisplay, robotLocation, robotOrientation, robotInventory
   , installedDevices
-  , robotCtx, robotEnv, machine, tickSteps
+  , robotCtx, robotEnv, machine, selfDestruct, tickSteps
 
     -- ** Create
 
@@ -67,6 +67,9 @@ data Robot = Robot
 
   , _machine          :: CEK
     -- ^ The current state of the robot's CEK machine.
+
+  , _selfDestruct     :: Bool
+    -- ^ Whether the robot wants to self-destruct.
 
   , _tickSteps        :: Int
     -- ^ The need for 'tickSteps' is a bit technical, and I hope I can
@@ -144,6 +147,7 @@ mkRobot name l d m devs = Robot
   , _robotCtx      = M.empty
   , _robotEnv      = V.empty
   , _machine       = m
+  , _selfDestruct  = False
   , _tickSteps     = 0
   }
 
@@ -160,6 +164,7 @@ baseRobot = Robot
   , _robotCtx      = M.empty
   , _robotEnv      = V.empty
   , _machine       = idleMachine
+  , _selfDestruct  = False
   , _tickSteps     = 0
   }
 

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -206,6 +206,13 @@ stepRobot r = case r ^. machine of
   -- the body in a suitably extended environment.
   Out v1 (FLet x t2 e : k)          -> step r $ In t2 (addBinding x v1 e) k
 
+  -- If we were running a try block but evaluation completed normally,
+  Out v (FTry _ _ : k)              -> step r $ Out v k
+
+  Out (VString s) (FRaise : k)                -> step r $ Up (User s) k
+  cek@(Out _ (FRaise : k)) ->
+    error $ "Panic! Bad machine state in stepRobot, FRaise of non-string: " ++ show cek
+
   -- Definitions immediately turn into VDef values, awaiting execution.
   In (TDef x _ t) e k               -> step r $ Out (VDef x t e) k
 

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -25,7 +25,7 @@ import           Control.Lens            hiding (Const, from, parts)
 import           Control.Monad.Except
 import           Control.Monad.State
 import qualified Data.Map                as M
-import           Data.Maybe              (fromJust, listToMaybe)
+import           Data.Maybe              (fromJust, isNothing, listToMaybe)
 import           Data.Text               (Text)
 import qualified Data.Text               as T
 import           Linear
@@ -482,7 +482,8 @@ execConst Place [VString s] k = do
   loc <- use robotLocation
 
   -- Make sure there's nothing already here
-  _ <- entityAt loc >>= (`isJustOr` cmdExn Place ["There is already an entity here."])
+  nothingHere <- isNothing <$> entityAt loc
+  nothingHere `holdsOr` cmdExn Place ["There is already an entity here."]
 
   -- Make sure the robot has the thing in its inventory
   e <- listToMaybe (lookupByName s inv) `isJustOr`

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -610,7 +610,8 @@ execConst (Cmp c) [v1, v2] k =
     Just b  -> return $ Out (VBool b) k
 execConst (Cmp c) args k     = badConst (Cmp c) args k
 
-execConst (Arith Neg) [VInt n] k = return $ Out (VInt (-n)) k
+execConst Neg [VInt n] k = return $ Out (VInt (-n)) k
+execConst Neg args k = badConst Neg args k
 execConst (Arith c) [VInt n1, VInt n2] k = return $ Out (VInt (evalArith c n1 n2)) k
 execConst (Arith c) args k = badConst (Arith c) args k
 
@@ -709,18 +710,19 @@ compareValues = \case
   VBind{}       -> const Nothing
   VDelay{}      -> const Nothing
 
--- XXX Split Arith into binary + unary so we don't have to have silly
--- special cases like this
-
 -- | Evaluate the application of an arithmetic operator.
 evalArith :: ArithConst -> Integer -> Integer -> Integer
-evalArith Neg = error "evalArith Neg: should have been handled already"
 evalArith Add = (+)
 evalArith Sub = (-)
 evalArith Mul = (*)
 evalArith Div = safeDiv
-evalArith Exp = (^)
+evalArith Exp = safeExp
 
 safeDiv :: Integer -> Integer -> Integer
 safeDiv _ 0 = 42
 safeDiv a b = a `div` b
+
+safeExp :: Integer -> Integer -> Integer
+safeExp a b
+  | b < 0     = 42
+  | otherwise = a^b

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -122,71 +122,60 @@ bigStepRobotRec r
   | not (isActive r) || r ^. tickSteps <= 0 = return r
   | otherwise           = stepRobot r >>= bigStepRobotRec
 
--- | Helper function for accomplishing a single step: given a robot
---   and a new CEK machine state, decrement its @tickSteps@ and set
---   its CEK machine to the new state.  This function always returns
---   @Just@ a robot.
-step :: (MonadState GameState m, MonadIO m) => Robot -> CEK -> m Robot
-step r cek = do
-
-  -- for debugging. Uncomment to get a sequence of CEK machine states
-  -- printed to an output file.
-  -- liftIO $ appendFile "out.txt" (prettyCEK (r ^. machine))
-
-  return $ r & tickSteps -~ 1 & machine .~ cek
-
--- | Step to an updated robot and continuation, producing a unit-value
---   output.  @stepUnit r k == step r (Out VUnit k)@.
-stepUnit :: (MonadState GameState m, MonadIO m) => Robot -> Cont -> m Robot
-stepUnit r k = step r $ Out VUnit k
+-- | Single-step a robot by decrementing its 'tickSteps' counter and
+--   running its CEK machine for one step.
+stepRobot :: (MonadState GameState m, MonadIO m) => Robot -> m Robot
+stepRobot r = do
+  (cek', r') <- runStateT (stepCEK (r ^. machine)) (r & tickSteps -~ 1)
+  return $ r' & machine .~ cek'
 
 -- | The main CEK machine workhorse.  Given a robot, look at its CEK
 --   machine state and figure out a single next step.
-stepRobot :: (MonadState GameState m, MonadIO m) => Robot -> m Robot
-stepRobot r = case r ^. machine of
+stepCEK :: (MonadState GameState m, MonadIO m) => CEK -> StateT Robot m CEK
+stepCEK cek = case cek of
 
   ------------------------------------------------------------
   -- Evaluation
 
   -- First some straightforward cases.  These all immediately turn
   -- into values.
-  In TUnit _ k                      -> stepUnit r k
-  In (TDir d) _ k                   -> step r $ Out (VDir d) k
-  In (TInt n) _ k                   -> step r $ Out (VInt n) k
-  In (TString s) _ k                -> step r $ Out (VString s) k
-  In (TBool b) _ k                  -> step r $ Out (VBool b) k
+  In TUnit _ k                      -> return $ Out VUnit k
+  In (TDir d) _ k                   -> return $ Out (VDir d) k
+  In (TInt n) _ k                   -> return $ Out (VInt n) k
+  In (TString s) _ k                -> return $ Out (VString s) k
+  In (TBool b) _ k                  -> return $ Out (VBool b) k
 
   -- A constant is turned into a VCApp which might be waiting for arguments.
-  In (TConst c) _ k                 -> step r $ Out (VCApp c []) k
+  In (TConst c) _ k                 -> return $ Out (VCApp c []) k
 
   -- To evaluate a variable, just look it up in the context.
-  In (TVar x) e k                   -> step r $ Out (e !!! x) k
+  In (TVar x) e k                   -> return $ Out (e !!! x) k
 
   -- To evaluate a pair, start evaluating the first component.
-  In (TPair t1 t2) e k              -> step r $ In t1 e (FSnd t2 e : k)
+  In (TPair t1 t2) e k              -> return $ In t1 e (FSnd t2 e : k)
   -- Once that's done, evaluate the second component.
-  Out v1 (FSnd t2 e : k)            -> step r $ In t2 e (FFst v1 : k)
+  Out v1 (FSnd t2 e : k)            -> return $ In t2 e (FFst v1 : k)
   -- Finally, put the results together into a pair value.
-  Out v2 (FFst v1 : k)              -> step r $ Out (VPair v1 v2) k
+  Out v2 (FFst v1 : k)              -> return $ Out (VPair v1 v2) k
 
   -- Lambdas immediately turn into closures.
-  In (TLam x _ t) e k               -> step r $ Out (VClo x t e) k
+  In (TLam x _ t) e k               -> return $ Out (VClo x t e) k
 
   -- To evaluate an application, start by focusing on the left-hand
   -- side and saving the argument for later.
-  In (TApp t1 t2) e k               -> step r $ In t1 e (FArg t2 e : k)
+  In (TApp t1 t2) e k               -> return $ In t1 e (FArg t2 e : k)
   -- Once that's done, switch to evaluating the argument.
-  Out v1 (FArg t2 e : k)            -> step r $ In t2 e (FApp v1 : k)
+  Out v1 (FArg t2 e : k)            -> return $ In t2 e (FApp v1 : k)
   -- We can evaluate an application of a closure in the usual way.
-  Out v2 (FApp (VClo x t e) : k)    -> step r $ In t (addBinding x v2 e) k
+  Out v2 (FApp (VClo x t e) : k)    -> return $ In t (addBinding x v2 e) k
   -- We can also evaluate an application of a constant by collecting
   -- arguments, eventually dispatching to evalConst for function
   -- constants.
   Out v2 (FApp (VCApp c args) : k)
     | not (isCmd c) &&
-      arity c == length args + 1    -> evalConst c (reverse (v2 : args)) k r
-    | otherwise                     -> step r $ Out (VCApp c (v2 : args)) k
-  cek@(Out _ (FApp _ : _))         ->
+      arity c == length args + 1    -> evalConst c (reverse (v2 : args)) k
+    | otherwise                     -> return $ Out (VCApp c (v2 : args)) k
+  Out _ (FApp _ : _)                ->
     error $ "Panic! Bad machine state in stepRobot, FApp of non-function: " ++ show cek
 
   -- Evaluating let expressions is a little bit tricky. We start by
@@ -198,22 +187,22 @@ stepRobot r = case r ^. machine of
   In (TLet x _ t1 t2) e k           ->
     let e' = addBinding x (VDelay t1 e') e   -- XXX do this without making a recursive
                                              -- (hence unprintable) env?
-    in step r $ In t1 e' (FLet x t2 e : k)
+    in return $ In t1 e' (FLet x t2 e : k)
 
   -- Once we've finished with the let-binding, we switch to evaluating
   -- the body in a suitably extended environment.
-  Out v1 (FLet x t2 e : k)          -> step r $ In t2 (addBinding x v1 e) k
+  Out v1 (FLet x t2 e : k)          -> return $ In t2 (addBinding x v1 e) k
 
   -- Definitions immediately turn into VDef values, awaiting execution.
-  In (TDef x _ t) e k               -> step r $ Out (VDef x t e) k
+  In (TDef x _ t) e k               -> return $ Out (VDef x t e) k
 
   -- Bind expressions don't evaluate: just package it up as a value
   -- until such time as it is to be executed.
-  In (TBind mx t1 t2) e k           -> step r $ Out (VBind mx t1 t2 e) k
+  In (TBind mx t1 t2) e k           -> return $ Out (VBind mx t1 t2 e) k
 
   -- Delay expressions immediately turn into VDelay values, awaiting
   -- application of 'Force'.
-  In (TDelay t) e k                  -> step r $ Out (VDelay t e) k
+  In (TDelay t) e k                  -> return $ Out (VDelay t e) k
 
   ------------------------------------------------------------
   -- Execution
@@ -223,22 +212,23 @@ stepRobot r = case r ^. machine of
   -- result should be bound to the given name.
   Out (VDef x t e) (FExec : k)       ->
     let e' = addBinding x (VDelay t e') e
-    in  step r $ In t e' (FDef x : k)
+    in  return $ In t e' (FDef x : k)
   -- Once we are done evaluating the body of a definition, we return a
   -- special VResult value, which packages up the return value from
   -- the @def@ command itself (@unit@) together with the resulting
   -- environment (the variable bound to the value).
-  Out v  (FDef x : k)                -> step r $ Out (VResult VUnit (V.singleton x v)) k
+  Out v  (FDef x : k)                -> return $ Out (VResult VUnit (V.singleton x v)) k
 
   -- To execute a constant application, delegate to the 'execConst'
   -- function.  Set tickSteps to 0 if the command is supposed to take
   -- a tick, so the robot won't take any more steps this tick.
-  Out (VCApp c args) (FExec : k)     ->
-    execConst c (reverse args) k (r & if takesTick c then tickSteps .~ 0 else id)
+  Out (VCApp c args) (FExec : k)     -> do
+    when (takesTick c) $ tickSteps .= 0
+    execConst c (reverse args) k
 
   -- To execute a bind expression, evaluate and execute the first
   -- command, and remember the second for execution later.
-  Out (VBind mx c1 c2 e) (FExec : k)  -> step r $ In c1 e (FExec : FBind mx c2 e : k)
+  Out (VBind mx c1 c2 e) (FExec : k)  -> return $ In c1 e (FExec : FBind mx c2 e : k)
   -- If first command completes with a value along with an environment
   -- resulting from definition commands, switch to evaluating the
   -- second command of the bind.  Extend the environment with both the
@@ -249,60 +239,62 @@ stepRobot r = case r ^. machine of
   -- environment with the definition environment from the first
   -- command.
   Out (VResult v ve) (FBind mx t2 e : k) ->
-    step r $ In t2 (ve `V.union` maybe id (`addBinding` v) mx e) (FExec : FUnionEnv ve : k)
+    return $ In t2 (ve `V.union` maybe id (`addBinding` v) mx e) (FExec : FUnionEnv ve : k)
   -- On the other hand, if the first command completes with a simple value,
   -- we do something similar, but don't have to worry about the environment.
   Out v (FBind mx t2 e : k) ->
-    step r $ In t2 (maybe id (`addBinding` v) mx e) (FExec : k)
+    return $ In t2 (maybe id (`addBinding` v) mx e) (FExec : k)
   -- If a command completes with a value and definition environment,
   -- and the next continuation frame contains a previous environment
   -- to union with, then pass the unioned environments along in
   -- another VResult.
 
-  Out (VResult v e2) (FUnionEnv e1 : k) -> step r $ Out (VResult v (e2 `V.union` e1)) k
+  Out (VResult v e2) (FUnionEnv e1 : k) -> return $ Out (VResult v (e2 `V.union` e1)) k
   -- Or, if a command completes with no environment, but there is a
   -- previous environment to union with, just use that environment.
-  Out v (FUnionEnv e : k)               -> step r $ Out (VResult v e) k
+  Out v (FUnionEnv e : k)               -> return $ Out (VResult v e) k
 
   -- If the top of the continuation stack contains a 'FLoadEnv' frame,
   -- it means we are supposed to load up the resulting definition
   -- environment and type context into the robot's top-level
   -- environment and type context, so they will be available to future
   -- programs.
-  Out (VResult v e) (FLoadEnv ctx : k)  ->
-    step (r & robotEnv %~ V.union e & robotCtx %~ M.union ctx) $ Out v k
-  Out v (FLoadEnv _ : k)                -> step r $ Out v k
+  Out (VResult v e) (FLoadEnv ctx : k)  -> do
+    robotEnv %= V.union e
+    robotCtx %= M.union ctx
+    return $ Out v k
+  Out v (FLoadEnv _ : k)                -> return $ Out v k
 
   -- Exception handling.
   -- First, if we were running a try block but evaluation completed normally,
   -- just ignore the try block and continue.
-  Out v (FTry _ _ : k)                  -> step r $ Out v k
+  Out v (FTry _ _ : k)                  -> return $ Out v k
   -- If we are raising an exception up the continuation stack and come
   -- to a Try frame, execute the associated catch block.
-  Up _ (FTry t e : k)                   -> step r $ In t e (FExec : k)
+  Up _ (FTry t e : k)                   -> return $ In t e (FExec : k)
   -- Otherwise, keep popping from the continuation stack.
-  Up exn (_ : k)                        -> step r $ Up exn k
+  Up exn (_ : k)                        -> return $ Up exn k
   -- If an exception rises all the way to the top level without being
   -- handled, turn it into an error message via the 'say' command.
-  Up  exn []                            -> step r $ In (TApp (TConst Say) (TString (formatExn exn))) V.empty [FExec]
+  Up  exn []                            -> return $ In (TApp (TConst Say) (TString (formatExn exn))) V.empty [FExec]
 
-  cek@(Out (VResult _ _) _) ->
+  Out (VResult _ _) _ ->
     error $ "Panic! Bad machine state in stepRobot: no appropriate stack frame to catch a VResult: " ++ show cek
 
-  cek@(Out _ (FExec : _)) ->
+  Out _ (FExec : _) ->
     error $ "Panic! Bad machine state in stepRobot: FExec frame with non-executable value: " ++ show cek
 
   -- Finally, if we're done evaluating and the continuation stack is
-  -- empty, return the robot unchanged.
-  Out _ []                          -> return r
+  -- empty, return the machine unchanged.
+  done@(Out _ [])                        -> return done
 
 -- | Determine whether a constant should take up a tick or not when executed.
 takesTick :: Const -> Bool
 takesTick c = isCmd c && (c `notElem` [Halt, Noop, Return, GetX, GetY, Ishere])
 
 -- | Emit a formatted error message.
-emitError :: MonadState GameState m => Robot -> Const -> [Text] -> m ()
-emitError r c parts = emitMessage (formatError r c parts)
+emitError :: MonadState GameState m => Const -> [Text] -> StateT Robot m ()
+emitError c parts = get >>= \r -> lift (emitMessage (formatError r c parts))
 
 -- | Create a standard formatted error containing the robot name and
 --   the name of the command that caused the error.
@@ -314,16 +306,17 @@ formatError r c = T.unwords . (colon (r ^. robotName) :) . (colon (prettyText c)
 -- | Require that a robot has a given device installed, OR we are in
 --   creative mode.  Run the first (failure) continuation if not, and
 --   the second (success) continuation if so.
-require :: MonadState GameState m => Robot -> Entity -> m a -> m a -> m a
-require r e fk sk = do
-  mode <- use gameMode
+require :: MonadState GameState m => Entity -> StateT Robot m a -> StateT Robot m a -> StateT Robot m a
+require e fk sk = do
+  mode <- lift $ use gameMode
+  r <- get
   if mode == Creative || r `hasInstalled` e then sk else fk
 
 -- | At the level of the CEK machine there's no particular difference
 --   between *evaluating* a function constant and *executing* a
 --   command constant, but it somehow feels better to have two
 --   different names for it anyway.
-evalConst :: (MonadState GameState m, MonadIO m) => Const -> [Value] -> Cont -> Robot -> m Robot
+evalConst :: (MonadState GameState m, MonadIO m) => Const -> [Value] -> Cont -> StateT Robot m CEK
 evalConst = execConst
 
 -- XXX load this from a file and have it available in a map?
@@ -350,57 +343,63 @@ seedProgram thing = prog
 
 -- | Interpret the execution (or evaluation) of a constant application
 --   to some values.
-execConst :: (MonadState GameState m, MonadIO m) => Const -> [Value] -> Cont -> Robot -> m Robot
+execConst :: (MonadState GameState m, MonadIO m) => Const -> [Value] -> Cont -> StateT Robot m CEK
 
-execConst Noop _ k r     = stepUnit r k
-execConst Return [v] k r = step r $ Out v k
-execConst Return vs k _  = badConst Return vs k
-execConst Wait _ k r     = stepUnit r k
-execConst Halt _ k r     = updated .= True >> stepUnit (r & selfDestruct .~ True) k
+execConst Noop _ k     = return $ Out VUnit k
+execConst Return [v] k = return $ Out v k
+execConst Return vs k  = badConst Return vs k
+execConst Wait _ k     = return $ Out VUnit k
+execConst Halt _ k     = do
+  lift $ updated .= True
+  selfDestruct .= True
+  return $ Out VUnit k
 
-execConst Move _ k r     = do
+execConst Move _ k     = do
+  r <- get
   let V2 x y = (r ^. robotLocation) ^+^ (r ^. robotOrientation ? zero)
-  me <- uses world (W.lookupEntity (-y,x))
-  require r E.treads
-    (emitError r Move ["You need treads to move."] >> stepUnit r k)
+  me <- lift $ uses world (W.lookupEntity (-y,x))
+  require E.treads
+    (emitError Move ["You need treads to move."] >> return (Out VUnit k))
     case maybe True (not . (`hasProperty` Unwalkable)) me of
 
       -- There's something there, and we can't walk on it.
       -- It seems like it would be super annoying for this to generate
       -- an error message or throw an exception!  We just consider this
       -- normal operation of the Move instruction when a robot is blocked.
-      False -> stepUnit r k
+      False -> return $ Out VUnit k
 
       -- Otherwise, move forward.
       True -> do
-        updated .= True
-        stepUnit (r & robotLocation %~ (^+^ (r ^. robotOrientation ? zero))) k
+        lift $ updated .= True
+        robotLocation %= (^+^ (r ^. robotOrientation ? zero))
+        return $ Out VUnit k
 
-execConst Grab _ k r =
-  require r E.grabber
-    (emitError r Grab ["You need a grabber device to grab things."] >> stepUnit r k)
+execConst Grab _ k =
+  require E.grabber
+    (emitError Grab ["You need a grabber device to grab things."] >> return (Out VUnit k))
     do
+      r <- get
       let V2 x y = r ^. robotLocation
-      me <- uses world (W.lookupEntity (-y,x))
+      me <- lift (uses world (W.lookupEntity (-y,x)))
       case me of
 
         -- No entity here.
-        Nothing -> emitError r Grab ["There is nothing here to grab."] >> stepUnit r k
+        Nothing -> emitError Grab ["There is nothing here to grab."] >> return (Out VUnit k)
 
         -- There is an entity here...
         Just e -> case e `hasProperty` Portable of
 
           -- ...but it can't be picked up.
           False -> do
-            emitError r Grab ["The", e ^. entityName, "here can't be grabbed."]
-            stepUnit r k
+            emitError Grab ["The", e ^. entityName, "here can't be grabbed."]
+            return $ Out VUnit k
 
           -- ...and it can be picked up.
           True -> do
-            updated .= True
-
             -- Remove the entity from the world.
-            world %= W.update (-y,x) (const Nothing)
+            lift $ do
+              updated .= True
+              world %= W.update (-y,x) (const Nothing)
 
             when (e `hasProperty` Growable) $ do
 
@@ -412,164 +411,175 @@ execConst Grab _ k r =
                       & robotDisplay .~
                         (defaultEntityDisplay '.' & displayAttr .~ plantAttr)
                       & robotInventory .~ E.singleton e
-              _ <- addRobot seedBot
+              _ <- lift $ addRobot seedBot
               return ()
 
             -- Add the picked up item to the robot's inventory
-            stepUnit (r & robotInventory %~ insert e) k
+            robotInventory %= insert e
+            return $ Out VUnit k
 
-execConst Turn [VDir d] k r = do
-  require r E.treads
-    (emitError r Turn ["You need treads to turn."] >> stepUnit r k)
+execConst Turn [VDir d] k = do
+  require E.treads
+    (emitError Turn ["You need treads to turn."] >> return (Out VUnit k))
     do
-      updated .= True
-      stepUnit (r & robotOrientation . _Just %~ applyTurn d) k
-execConst Turn args k _ = badConst Turn args k
+      lift $ updated .= True
+      robotOrientation . _Just %= applyTurn d
+      return $ Out VUnit k
+
+execConst Turn args k = badConst Turn args k
 
 -- XXX do we need a device to do placement?
-execConst Place [VString s] k r = do
+execConst Place [VString s] k = do
+  r <- get
   let V2 x y = r ^. robotLocation
-  me <- uses world (W.lookupEntity (-y, x))
+  me <- lift $ uses world (W.lookupEntity (-y, x))
   case me of
-    Just _  -> emitError r Place ["There is already an entity here."] >> stepUnit r k
+    Just _  -> emitError Place ["There is already an entity here."] >> return (Out VUnit k)
     Nothing -> case lookupByName s (r ^. robotInventory) of
-      []    -> emitError r Place ["You don't have", indefinite s, "to place."] >> stepUnit r k
+      []    -> emitError Place ["You don't have", indefinite s, "to place."] >> return (Out VUnit k)
       (e:_) -> do
-        updated .= True
-        world %= W.update (-y, x) (const (Just e))
-        stepUnit (r & robotInventory %~ delete e) k
-execConst Place args k _ = badConst Place args k
+        lift $ do
+          updated .= True
+          world %= W.update (-y, x) (const (Just e))
+        robotInventory %= delete e
+        return $ Out VUnit k
+execConst Place args k = badConst Place args k
 
 -- XXX need a device to give --- but it should be available from the beginning
-execConst Give [VString otherName, VString itemName] k r = do
-  mother <- use (robotMap . at otherName)
+execConst Give [VString otherName, VString itemName] k = do
+  r <- get
+  mother <- lift $ use (robotMap . at otherName)
   let mitem = listToMaybe . lookupByName itemName $ (r ^. robotInventory)
   case (mother, mitem) of
     (Just _, Just item) -> do
-      robotMap . at otherName . _Just . robotInventory %= insert item
-      stepUnit (r & robotInventory %~ delete item) k
+      lift $ robotMap . at otherName . _Just . robotInventory %= insert item
+      robotInventory %= delete item
+      return $ Out VUnit k
     (Nothing, _) -> do
-      emitError r Give ["There is no robot named", otherName, "here." ]
-      stepUnit r k
+      emitError Give ["There is no robot named", otherName, "here." ]
+      return $ Out VUnit k
     (_, Nothing) -> do
-      emitError r Give ["You don't have", indefinite itemName, "to give." ]
-      stepUnit r k
+      emitError Give ["You don't have", indefinite itemName, "to give." ]
+      return $ Out VUnit k
 
-execConst Give args k _ = badConst Give args k
+execConst Give args k = badConst Give args k
 
 -- XXX do we need a device to craft?
-execConst Craft [VString name] k r =
+execConst Craft [VString name] k = do
+  inv <- use robotInventory
   case listToMaybe $ lookupByName name E.entityCatalog of
-    Nothing -> emitError r Craft ["I've never heard of", indefiniteQ name, "."] >> stepUnit r k
+    Nothing -> emitError Craft ["I've never heard of", indefiniteQ name, "."] >> return (Out VUnit k)
     Just e  -> case recipeFor e of
       Nothing -> do
-        emitError r Craft ["There is no known recipe for crafting", indefinite name, "."]
-        stepUnit r k
-      Just recipe -> case craft recipe (r ^. robotInventory) of
+        emitError Craft ["There is no known recipe for crafting", indefinite name, "."]
+        return $ Out VUnit k
+      Just recipe -> case craft recipe inv of
         -- XXX describe the missing ingredients
         Left missing -> do
-          emitError r Craft ["Missing ingredients:", prettyIngredientList missing]
-          stepUnit r k
-        Right inv'    -> stepUnit (r & robotInventory .~ inv') k
+          emitError Craft ["Missing ingredients:", prettyIngredientList missing]
+          return $ Out VUnit k
+        Right inv'    -> do
+          robotInventory .= inv'
+          return $ Out VUnit k
 
-execConst Craft args k _ = badConst Craft args k
+execConst Craft args k = badConst Craft args k
 
 
-execConst GetX _ k r = step r $ Out (VInt (fromIntegral x)) k
-  where
-    V2 x _ = r ^. robotLocation
-execConst GetY _ k r = step r $ Out (VInt (fromIntegral y)) k
-  where
-    V2 _ y = r ^. robotLocation
+execConst GetX _ k = do
+  V2 x _ <- use robotLocation
+  return $ Out (VInt (fromIntegral x)) k
+execConst GetY _ k = do
+  V2 _ y <- use robotLocation
+  return $ Out (VInt (fromIntegral y)) k
 
-execConst Random [VInt hi] k r = do
+execConst Random [VInt hi] k = do
   n <- randomRIO (0, hi-1)
-  step r $ Out (VInt n) k
-execConst Random args k _ = badConst Random args k
+  return $ Out (VInt n) k
+execConst Random args k = badConst Random args k
 
-execConst Say [VString s] k r = do
-  emitMessage (T.concat [r ^. robotName, ": ", s])
-  stepUnit r k
-execConst Say args k _ = badConst Say args k
+execConst Say [VString s] k = do
+  rn <- use robotName
+  lift $ emitMessage (T.concat [rn, ": ", s])
+  return $ Out VUnit k
+execConst Say args k = badConst Say args k
 
-execConst View [VString s] k r = do
-  mr <- use (robotMap . at s)
+execConst View [VString s] k = do
+  mr <- lift $ use (robotMap . at s)
   case mr of
-    Nothing -> emitError r View [ "There is no robot named ", s, " to view." ]
-    Just _  -> viewCenterRule .= VCRobot s
-  stepUnit r k
-execConst View args k _ = badConst View args k
+    Nothing -> emitError View [ "There is no robot named ", s, " to view." ]
+    Just _  -> lift $ viewCenterRule .= VCRobot s
+  return $ Out VUnit k
+execConst View args k = badConst View args k
 
-execConst Appear [VString s] k r = do
-  updated .= True
+execConst Appear [VString s] k = do
+  lift $ updated .= True
   case into @String s of
-    [c] ->
-      stepUnit
-        (r & robotDisplay . defaultChar .~ c
-           & robotDisplay . orientationMap .~ M.empty
-        )
-        k
-    [c,nc,ec,sc,wc] ->
-      stepUnit
-        ( r & robotDisplay . defaultChar .~ c
-            & robotDisplay . orientationMap . ix north .~ nc
-            & robotDisplay . orientationMap . ix east  .~ ec
-            & robotDisplay . orientationMap . ix south .~ sc
-            & robotDisplay . orientationMap . ix west  .~ wc
-        )
-        k
-    _other -> do
-      emitError r Appear [quote s, "is not a valid appearance string."]
-      stepUnit r k
-execConst Appear args k _ = badConst Appear args k
+    [c] -> do
+      robotDisplay . defaultChar .= c
+      robotDisplay . orientationMap .= M.empty
+      return $ Out VUnit k
 
-execConst Ishere [VString s] k r = do
-  let V2 x y = r ^. robotLocation
-  me <- uses world (W.lookupEntity (-y, x))
+    [c,nc,ec,sc,wc] -> do
+      robotDisplay . defaultChar .= c
+      robotDisplay . orientationMap . ix north .= nc
+      robotDisplay . orientationMap . ix east  .= ec
+      robotDisplay . orientationMap . ix south .= sc
+      robotDisplay . orientationMap . ix west  .= wc
+      return $ Out VUnit k
+
+    _other -> do
+      emitError Appear [quote s, "is not a valid appearance string."]
+      return $ Out VUnit k
+execConst Appear args k = badConst Appear args k
+
+execConst Ishere [VString s] k = do
+  V2 x y <-use robotLocation
+  me <- lift $ uses world (W.lookupEntity (-y, x))
   -- XXX encapsulate the above into a function, used several times
 
   case me of
-    Nothing -> step r $ Out (VBool False) k
-    Just e  -> step r $ Out (VBool (T.toLower (e ^. entityName) == T.toLower s)) k
-execConst Ishere args k _ = badConst Ishere args k
+    Nothing -> return $ Out (VBool False) k
+    Just e  -> return $ Out (VBool (T.toLower (e ^. entityName) == T.toLower s)) k
+execConst Ishere args k = badConst Ishere args k
 
-execConst Not [VBool b] k r = step r $ Out (VBool (not b)) k
-execConst Not args k _ = badConst Not args k
+execConst Not [VBool b] k = return $ Out (VBool (not b)) k
+execConst Not args k = badConst Not args k
 
-execConst (Cmp c) [v1, v2] k r =
+execConst (Cmp c) [v1, v2] k =
   case evalCmp c v1 v2 of
-    Nothing -> step r $ Out (VBool False) k  --- XXX raise an exception!
-    Just b  -> step r $ Out (VBool b) k
-execConst (Cmp c) args k _     = badConst (Cmp c) args k
+    Nothing -> return $ Out (VBool False) k  --- XXX raise an exception!
+    Just b  -> return $ Out (VBool b) k
+execConst (Cmp c) args k     = badConst (Cmp c) args k
 
-execConst (Arith Neg) [VInt n] k r = step r $ Out (VInt (-n)) k
-execConst (Arith c) [VInt n1, VInt n2] k r = step r $ Out (VInt (evalArith c n1 n2)) k
-execConst (Arith c) args k _ = badConst (Arith c) args k
+execConst (Arith Neg) [VInt n] k = return $ Out (VInt (-n)) k
+execConst (Arith c) [VInt n1, VInt n2] k = return $ Out (VInt (evalArith c n1 n2)) k
+execConst (Arith c) args k = badConst (Arith c) args k
 
-execConst Force [VDelay t e] k r = step r $ In t e k
-execConst Force args k _ = badConst Force args k
+execConst Force [VDelay t e] k = return $ In t e k
+execConst Force args k = badConst Force args k
 
   -- Note, if should evaluate the branches lazily, but since
   -- evaluation is eager, by the time we get here thn and els have
   -- already been fully evaluated --- what gives?  The answer is that
   -- we rely on elaboration to add 'lazy' wrappers around the branches
   -- (and a 'force' wrapper around the entire if).
-execConst If [VBool True , thn, _] k r = step r $ Out thn k
-execConst If [VBool False, _, els] k r = step r $ Out els k
-execConst If args k _ = badConst If args k
+execConst If [VBool True , thn, _] k = return $ Out thn k
+execConst If [VBool False, _, els] k = return $ Out els k
+execConst If args k = badConst If args k
 
-execConst Fst [VPair v _] k r = step r $ Out v k
-execConst Fst args k _        = badConst Fst args k
-execConst Snd [VPair _ v] k r = step r $ Out v k
-execConst Snd args k _        = badConst Snd args k
+execConst Fst [VPair v _] k = return $ Out v k
+execConst Fst args k        = badConst Fst args k
+execConst Snd [VPair _ v] k = return $ Out v k
+execConst Snd args k        = badConst Snd args k
 
-execConst Try [VDelay t1 e1, VDelay t2 e2] k r = step r $ In t1 e1 (FExec : FTry t2 e2 : k)
-execConst Try args k _        = badConst Try args k
+execConst Try [VDelay t1 e1, VDelay t2 e2] k = return $ In t1 e1 (FExec : FTry t2 e2 : k)
+execConst Try args k        = badConst Try args k
 
-execConst Raise [VString s] k r = step r $ Up (User s) k
-execConst Raise args k _        = badConst Raise args k
+execConst Raise [VString s] k = return $ Up (User s) k
+execConst Raise args k        = badConst Raise args k
 
-execConst Build [VString name, VDelay c e] k r = do
+execConst Build [VString name, VDelay c e] k = do
+  r <- get
   let newRobot =
         mkRobot
           name
@@ -578,20 +588,20 @@ execConst Build [VString name, VDelay c e] k r = do
           (In c e [FExec])  -- XXX require cap for env that gets shared here?
           [E.treads, E.grabber, E.solarPanels]
 
-  newRobot' <- addRobot newRobot
-  updated .= True
-  step r $ Out (VString (newRobot' ^. robotName)) k
-execConst Build args k _ = badConst Build args k
+  newRobot' <- lift $ addRobot newRobot
+  lift $ updated .= True
+  return $ Out (VString (newRobot' ^. robotName)) k
+execConst Build args k = badConst Build args k
 
-execConst Run [VString fileName] k r = do
+execConst Run [VString fileName] k = do
   mf <- liftIO $ readFileMay (into fileName)
   case mf of
-    Nothing -> emitError r Run ["File not found:", fileName] >> stepUnit r k
+    Nothing -> emitError Run ["File not found:", fileName] >> return (Out VUnit k)
     Just f -> case processTerm (into @Text f) of
       Left  err        -> do
-        emitError r Run ["Error while processing", fileName, "\n", err]
-        stepUnit r k
-      Right t -> step r $ initMachine' t V.empty k
+        emitError Run ["Error while processing", fileName, "\n", err]
+        return $ Out VUnit k
+      Right t -> return $ initMachine' t V.empty k
 
       -- Note, adding FExec to the stack above in the TyCmd case (done
       -- automatically by the initMachine function) is correct.  run
@@ -612,7 +622,7 @@ execConst Run [VString fileName] k r = do
       -- the fact that it is equivalent to (in pseudo-Haskell syntax)
       -- 'join . load'.
 
-execConst Run args k _ = badConst Run args k
+execConst Run args k = badConst Run args k
 
 badConst :: Const -> [Value] -> Cont -> a
 badConst c args k = error $

--- a/src/Swarm/Game/Value.hs
+++ b/src/Swarm/Game/Value.hs
@@ -77,10 +77,10 @@ data Value where
   --   commands.
   VResult :: Value -> Env -> Value
 
-  -- | A bind where the first component has been reduced to a value,
-  --   /i.e./ @v ; c@ or @x <- v; c@.  We also store an 'Env' in which
-  --   to interpret the second component of the bind.
-  VBind   :: Value -> Maybe Var -> Term -> Env -> Value
+  -- | An unevaluated bind expression, waiting to be executed, of the
+  --   form /i.e./ @c1 ; c2@ or @x <- c1; c2@.  We also store an 'Env'
+  --   in which to interpret the commands.
+  VBind   :: Maybe Var -> Term -> Term -> Env -> Value
 
   -- | A delayed term, along with its environment. If a term would
   --   otherwise be evaluated but we don't want it to be (/e.g./ as in
@@ -113,7 +113,7 @@ valueToTerm (VClo x t e)     =
 valueToTerm (VCApp c vs)     = foldl' TApp (TConst c) (reverse (map valueToTerm vs))
 valueToTerm (VDef x t _)     = TDef x Nothing t
 valueToTerm (VResult v _)    = valueToTerm v
-valueToTerm (VBind v mx t _) = TBind mx (valueToTerm v) t
+valueToTerm (VBind mx c1 c2 _) = TBind mx c1 c2
 valueToTerm (VDelay t _)     = TDelay t
 
 -- | An environment is a mapping from variable names to values.

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -105,6 +105,7 @@ constCaps Run       = S.empty
 
 constCaps Not       = S.empty
 constCaps (Cmp _)   = S.singleton CCmp
+constCaps Neg       = S.singleton CArith
 constCaps (Arith _) = S.singleton CArith
 
 constCaps If        = S.singleton CCond

--- a/src/Swarm/Language/Elaborate.hs
+++ b/src/Swarm/Language/Elaborate.hs
@@ -34,6 +34,15 @@ elaborate = bottomUp rewrite
     rewrite (TApp (TApp (TApp (TConst If) cond) thn) els)
       = TApp (TConst Force) (TApp (TApp (TApp (TConst If) cond) (TDelay thn)) (TDelay els))
 
+    -- try e catch ---> try (delay e) (delay catch)
+    --
+    -- Clearly we want to delay evaluation of the catch block.  But we
+    -- also want to delay evaluation of the first block, so that try
+    -- can put an appropriate frame on the stack before starting to
+    -- evaluate it (in case it raises an exception).
+    rewrite (TApp (TApp (TConst Try) thn) els)
+      = TApp (TApp (TConst Try) (TDelay thn)) (TDelay els)
+
     -- Rewrite any recursive occurrences of x inside t1 to (force x).
     -- When interpreting t1, we will put a binding (x |-> delay t1)
     -- in the context.

--- a/src/Swarm/Language/Elaborate.hs
+++ b/src/Swarm/Language/Elaborate.hs
@@ -34,15 +34,6 @@ elaborate = bottomUp rewrite
     rewrite (TApp (TApp (TApp (TConst If) cond) thn) els)
       = TApp (TConst Force) (TApp (TApp (TApp (TConst If) cond) (TDelay thn)) (TDelay els))
 
-    -- try e catch ---> try (delay e) (delay catch)
-    --
-    -- Clearly we want to delay evaluation of the catch block.  But we
-    -- also want to delay evaluation of the first block, so that try
-    -- can put an appropriate frame on the stack before starting to
-    -- evaluate it (in case it raises an exception).
-    rewrite (TApp (TApp (TConst Try) thn) els)
-      = TApp (TApp (TConst Try) (TDelay thn)) (TDelay els)
-
     -- Rewrite any recursive occurrences of x inside t1 to (force x).
     -- When interpreting t1, we will put a binding (x |-> delay t1)
     -- in the context.

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -235,7 +235,7 @@ parseExpr = makeExprParser parseTermAtom table
     table =
       [ [ InfixL (TApp <$ string "") ]
       , [ InfixR (mkOp (Arith Exp) <$ symbol "^") ]
-      , [ Prefix (TApp (TConst (Arith Neg)) <$ symbol "-") ]
+      , [ Prefix (TApp (TConst Neg) <$ symbol "-") ]
       , [ InfixL (mkOp (Arith Mul) <$ symbol "*")
         , InfixL (mkOp (Arith Div) <$ symbol "/")
         ]

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -60,7 +60,7 @@ reservedWords =
   , "random", "say", "view", "appear", "ishere"
   , "int", "string", "dir", "bool", "cmd"
   , "let", "def", "end", "in", "if", "true", "false", "not", "fst", "snd"
-  , "forall"
+  , "forall", "try", "raise"
   ]
 
 -- | Skip spaces and comments.
@@ -177,6 +177,8 @@ parseConst =
   <|> Not     <$ reserved "not"
   <|> Fst     <$ reserved "fst"
   <|> Snd     <$ reserved "snd"
+  <|> Try     <$ reserved "try"
+  <|> Raise   <$ reserved "raise"
 
 parseTermAtom :: Parser Term
 parseTermAtom =

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -13,10 +13,10 @@
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE PatternSynonyms      #-}
+{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns         #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Swarm.Language.Pretty where
 
@@ -33,11 +33,11 @@ import qualified Prettyprinter.Render.Text   as RT
 import           Control.Unification
 import           Control.Unification.IntVar
 
+import qualified Data.Text                   as T
 import           Swarm.Language.Syntax
 import           Swarm.Language.Typecheck
 import           Swarm.Language.Types
-import qualified Data.Text as T
-import Witch
+import           Witch
 
 -- | Type class for things that can be pretty-printed, given a
 --   precedence level of their context.
@@ -112,7 +112,7 @@ instance PrettyPrec Const where
   prettyPrec _ Noop      = "{}"
   prettyPrec p (Cmp c)   = prettyPrec p c
   prettyPrec p (Arith c) = prettyPrec p c
-  prettyPrec _ c         = pretty $ T.toTitle (from (show c))
+  prettyPrec _ c         = pretty $ T.toLower (from (show c))
 
 instance PrettyPrec CmpConst where
   prettyPrec _ CmpEq  = "=="

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -112,6 +112,7 @@ instance PrettyPrec Const where
   prettyPrec _ Noop      = "{}"
   prettyPrec p (Cmp c)   = prettyPrec p c
   prettyPrec p (Arith c) = prettyPrec p c
+  prettyPrec _ Neg       = "-"
   prettyPrec _ c         = pretty $ T.toLower (from (show c))
 
 instance PrettyPrec CmpConst where
@@ -123,7 +124,6 @@ instance PrettyPrec CmpConst where
   prettyPrec _ CmpGeq = ">="
 
 instance PrettyPrec ArithConst where
-  prettyPrec _ Neg = "-"
   prettyPrec _ Add = "+"
   prettyPrec _ Sub = "-"
   prettyPrec _ Mul = "*"

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -101,8 +101,9 @@ data Const
 
   -- Arithmetic
   | Not               -- ^ Logical negation.
-  | Cmp CmpConst      -- ^ Comparison operators.
-  | Arith ArithConst  -- ^ Arithmetic operators.
+  | Cmp CmpConst      -- ^ Binary comparison operators.
+  | Neg               -- ^ Arithmetic negation.
+  | Arith ArithConst  -- ^ Binary arithmetic operators.
 
   -- Language built-ins
   | If                -- ^ If-expressions.
@@ -120,7 +121,7 @@ data CmpConst = CmpEq | CmpNeq | CmpLt | CmpGt | CmpLeq | CmpGeq
   deriving (Eq, Ord, Show)
 
 -- | Arithmetic operator constants.
-data ArithConst = Neg | Add | Sub | Mul | Div | Exp
+data ArithConst = Add | Sub | Mul | Div | Exp
   deriving (Eq, Ord, Show)
 
 -- | The arity of a constant, /i.e./ how many arguments it expects.
@@ -148,6 +149,7 @@ arity Random    = 1
 arity Run       = 1
 arity Not       = 1
 arity (Cmp _)   = 2
+arity Neg       = 1
 arity (Arith _) = 2
 arity If        = 3
 arity Fst       = 1
@@ -172,7 +174,7 @@ isCmd (Cmp _)   = False
 isCmd (Arith _) = False
 isCmd c = c `notElem` funList
   where
-    funList = [If, Force, Not, Fst, Snd]
+    funList = [If, Force, Not, Neg, Fst, Snd]
 
 ------------------------------------------------------------
 -- Terms

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -110,6 +110,9 @@ data Const
   | Snd               -- ^ Second projection.
   | Force             -- ^ Force a delayed evaluation.
   | Return            -- ^ Return for the cmd monad.
+  | Try               -- ^ Try/catch block
+  | Raise             -- ^ Raise an exception
+
   deriving (Eq, Ord, Show)
 
 -- | Comparison operator constants.

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -372,7 +372,7 @@ inferConst Run         = Forall [] $ UTyFun UTyString (UTyCmd UTyUnit)
 
 inferConst Not         = Forall [] $ UTyFun UTyBool UTyBool
 inferConst (Cmp _)     = Forall ["a"] (UTyFun "a" (UTyFun "a" UTyBool))
-inferConst (Arith Neg) = Forall [] $ UTyFun UTyInt UTyInt
+inferConst Neg         = Forall [] $ UTyFun UTyInt UTyInt
 inferConst (Arith _)   = Forall [] $ UTyFun UTyInt (UTyFun UTyInt UTyInt)
 
 inferConst If          = Forall ["a"] $ UTyFun UTyBool (UTyFun "a" (UTyFun "a" "a"))

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -254,7 +254,7 @@ inferModule t = trivMod <$> infer t
 infer :: Term -> Infer UType
 
 infer   TUnit                     = return UTyUnit
-infer   (TConst c)                = inferConst c
+infer   (TConst c)                = instantiate $ inferConst c
 infer   (TDir _)                  = return UTyDir
 infer   (TInt _)                  = return UTyInt
 infer   (TString _)               = return UTyString
@@ -346,43 +346,42 @@ decomposePairTy _ ty = do
 
 -- | The types of some constants can be inferred.  Others (e.g. those
 --   that are overloaded or polymorphic) must be checked.
-inferConst :: Const -> Infer UType
-inferConst Wait        = return $ UTyCmd UTyUnit
-inferConst Noop        = return $ UTyCmd UTyUnit
-inferConst Halt        = return $ UTyCmd UTyUnit
+inferConst :: Const -> UPolytype
+inferConst Wait        = Forall [] $ UTyCmd UTyUnit
+inferConst Noop        = Forall [] $ UTyCmd UTyUnit
+inferConst Halt        = Forall [] $ UTyCmd UTyUnit
 
-inferConst Move        = return $ UTyCmd UTyUnit
-inferConst Turn        = return $ UTyFun UTyDir (UTyCmd UTyUnit)
-inferConst Grab        = return $ UTyCmd UTyUnit
-inferConst Place       = return $ UTyFun UTyString (UTyCmd UTyUnit)
-inferConst Give        = return $ UTyFun UTyString (UTyFun UTyString (UTyCmd UTyUnit))
-inferConst Craft       = return $ UTyFun UTyString (UTyCmd UTyUnit)
+inferConst Move        = Forall [] $ UTyCmd UTyUnit
+inferConst Turn        = Forall [] $ UTyFun UTyDir (UTyCmd UTyUnit)
+inferConst Grab        = Forall [] $ UTyCmd UTyUnit
+inferConst Place       = Forall [] $ UTyFun UTyString (UTyCmd UTyUnit)
+inferConst Give        = Forall [] $ UTyFun UTyString (UTyFun UTyString (UTyCmd UTyUnit))
+inferConst Craft       = Forall [] $ UTyFun UTyString (UTyCmd UTyUnit)
 inferConst Build       =
-  instantiate $ Forall ["a"] (UTyFun UTyString (UTyFun (UTyCmd "a") (UTyCmd UTyString)))
-inferConst Say         = return $ UTyFun UTyString (UTyCmd UTyUnit)
-inferConst View        = return $ UTyFun UTyString (UTyCmd UTyUnit)
-inferConst Appear      = return $ UTyFun UTyString (UTyCmd UTyUnit)
+  Forall ["a"] $ UTyFun UTyString (UTyFun (UTyCmd "a") (UTyCmd UTyString))
+inferConst Say         = Forall [] $ UTyFun UTyString (UTyCmd UTyUnit)
+inferConst View        = Forall [] $ UTyFun UTyString (UTyCmd UTyUnit)
+inferConst Appear      = Forall [] $ UTyFun UTyString (UTyCmd UTyUnit)
 
-inferConst GetX        = return $ UTyCmd UTyInt
-inferConst GetY        = return $ UTyCmd UTyInt
-inferConst Ishere      = return $ UTyFun UTyString (UTyCmd UTyBool)
-inferConst Random      = return $ UTyFun UTyInt (UTyCmd UTyInt)
+inferConst GetX        = Forall [] $ UTyCmd UTyInt
+inferConst GetY        = Forall [] $ UTyCmd UTyInt
+inferConst Ishere      = Forall [] $ UTyFun UTyString (UTyCmd UTyBool)
+inferConst Random      = Forall [] $ UTyFun UTyInt (UTyCmd UTyInt)
 
-inferConst Run         = return $ UTyFun UTyString (UTyCmd UTyUnit)
+inferConst Run         = Forall [] $ UTyFun UTyString (UTyCmd UTyUnit)
 
-inferConst Not         = return $ UTyFun UTyBool UTyBool
-inferConst (Cmp _)     = instantiate $ Forall ["a"] (UTyFun "a" (UTyFun "a" UTyBool))
-inferConst (Arith Neg) = return $ UTyFun UTyInt UTyInt
-inferConst (Arith _)   = return $ UTyFun UTyInt (UTyFun UTyInt UTyInt)
+inferConst Not         = Forall [] $ UTyFun UTyBool UTyBool
+inferConst (Cmp _)     = Forall ["a"] (UTyFun "a" (UTyFun "a" UTyBool))
+inferConst (Arith Neg) = Forall [] $ UTyFun UTyInt UTyInt
+inferConst (Arith _)   = Forall [] $ UTyFun UTyInt (UTyFun UTyInt UTyInt)
 
-inferConst If          = instantiate $
-  Forall ["a"] (UTyFun UTyBool (UTyFun "a" (UTyFun "a" "a")))
-inferConst Fst         = instantiate $ Forall ["a","b"] (UTyFun (UTyProd "a" "b") "a")
-inferConst Snd         = instantiate $ Forall ["a","b"] (UTyFun (UTyProd "a" "b") "b")
-inferConst Force       = instantiate $ Forall ["a"] "a"
-inferConst Return      = instantiate $ Forall ["a"] (UTyFun "a" (UTyCmd "a"))
-inferConst Try         = instantiate $ Forall ["a"] (UTyFun "a" (UTyFun "a" "a"))
-inferConst Raise       = instantiate $ Forall ["a"] (UTyFun UTyString "a")
+inferConst If          = Forall ["a"] $ UTyFun UTyBool (UTyFun "a" (UTyFun "a" "a"))
+inferConst Fst         = Forall ["a","b"] $ UTyFun (UTyProd "a" "b") "a"
+inferConst Snd         = Forall ["a","b"] $ UTyFun (UTyProd "a" "b") "b"
+inferConst Force       = Forall ["a"] $ UTyFun "a" "a"
+inferConst Return      = Forall ["a"] $ UTyFun "a" (UTyCmd "a")
+inferConst Try         = Forall ["a"] $ UTyFun (UTyCmd "a") (UTyFun (UTyCmd "a") (UTyCmd "a"))
+inferConst Raise       = Forall ["a"] $ UTyFun UTyString (UTyCmd "a")
 
 -- | @check t ty@ checks that @t@ has type @ty@.
 check :: Term -> UType -> Infer ()

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -381,6 +381,9 @@ inferConst Fst         = instantiate $ Forall ["a","b"] (UTyFun (UTyProd "a" "b"
 inferConst Snd         = instantiate $ Forall ["a","b"] (UTyFun (UTyProd "a" "b") "b")
 inferConst Force       = instantiate $ Forall ["a"] "a"
 inferConst Return      = instantiate $ Forall ["a"] (UTyFun "a" (UTyCmd "a"))
+inferConst Try         = instantiate $ Forall ["a"] (UTyFun "a" (UTyFun "a" "a"))
+inferConst Raise       = instantiate $ Forall ["a"] (UTyFun UTyString "a")
+
 -- | @check t ty@ checks that @t@ has type @ty@.
 check :: Term -> UType -> Infer ()
 check t ty = do

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -43,6 +43,7 @@ library
                       Swarm.Game.Display
                       Swarm.Game.Entity
                       Swarm.Game.Entities
+                      Swarm.Game.Exception
                       Swarm.Game.Recipes
                       Swarm.Game.Robot
                       Swarm.Game.State


### PR DESCRIPTION
The Swarm language now has exceptions.  Notable features:

- Exceptions can only be raised when executing commands.  Evaluating expressions of a non-`cmd` type cannot raise an exception.
- In order to make the above work, there are a couple things with undefined semantics, in particular dividing by zero and raising a base to a negative exponent.  These return integers but it is undefined which one you get (in practice, right now, it is 42).
- Added constants `try : cmd a -> cmd a -> cmd a` and `raise : string -> cmd a`.
- Many built-in commands now raise exceptions instead of printing a message; also took the opportunity to refactor and greatly simplify the code for the interpreter, flattening out a lot of nested error handling.
- Exceptions that are uncaught will cause a message to be printed.
- Also remove all calls to `error` and replace them with exceptions.  The goal is that the program should never, ever crash for any reason.
- There are three types of exceptions: user-generated exceptions are created via the `raise` command; command failures are generated by commands (*e.g.* `move` when there is something in front of the robot); fatal exceptions happen when there is some kind of bug in Swarm that leads to an internal inconsistency.  Only the first two kinds of exceptions can be caught by a `try` command.