### PR TITLE
Display the current game mode on the right side of the menu bar (Closes #38)

### DIFF
--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -97,6 +97,7 @@ drawUI s =
       , drawMenu
           (s ^. gameState . paused)
           ((s ^. gameState . viewCenterRule) == VCRobot "base")
+          (s ^. gameState . gameMode)
           (s ^. uiState)
       , panel highlightAttr fr REPLPanel
           ( plainBorder
@@ -147,12 +148,18 @@ drawDialog s = case s ^. uiError of
 -- | Draw a menu explaining what key commands are available for the
 --   current panel.  This menu is displayed as a single line in
 --   between the world panel and the REPL.
-drawMenu :: Bool -> Bool -> UIState -> Widget Name
-drawMenu isPaused viewingBase
+drawMenu :: Bool -> Bool -> GameMode -> UIState -> Widget Name
+drawMenu isPaused viewingBase mode
   = vLimit 1
-  . hBox . map (padLeftRight 1 . drawKeyCmd)
+  . hBox . (++[gameModeWidget]) . map (padLeftRight 1 . drawKeyCmd)
   . (globalKeyCmds++) . keyCmdsFor . focusGetCurrent . view uiFocusRing
   where
+    gameModeWidget
+      = padLeft Max . padLeftRight 1
+      . txt . (<> " mode")
+      $ case mode of
+          Classic -> "Classic"
+          Creative -> "Creative"
     globalKeyCmds =
       [ ("^q", "quit")
       , ("Tab", "cycle panels")


### PR DESCRIPTION
Putting the game mode in the menu bar is a bit cluttered with the TPS above and the type preview below, but I thought it looked better than putting it in the world border. If you disagree, just let me know and I'll change it.

![Screenshot_20210924_144952_cropped](https://user-images.githubusercontent.com/2855417/134725926-fc67d02b-9e97-493b-b2cc-e6cadd0e08da.png)