### PR TITLE
Further reduce maximum FPS to 30

### DIFF
--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -46,10 +46,13 @@ appMain = do
     Left errMsg -> T.putStrLn errMsg
     Right s -> do
 
-      -- Send Frame events as at a reasonable rate for 60 fps. The
+      -- Send Frame events as at a reasonable rate for 30 fps. The
       -- game is responsible for figuring out how many steps to take
       -- each frame to achieve the desired speed, regardless of the
-      -- frame rate.
+      -- frame rate.  Note that if the game cannot keep up with 30
+      -- fps, it's not a problem: the channel will fill up and this
+      -- thread will block.  So the force of the threadDelay is just
+      -- to set a *maximum* possible frame rate.
       --
       -- 5 is the size of the bounded channel; when it gets that big,
       -- any writes to it will block.  Probably 1 would work fine,
@@ -59,7 +62,7 @@ appMain = do
 
       chan <- newBChan 5
       _ <- forkIO $ forever $ do
-        threadDelay 16_666
+        threadDelay 33_333        -- cap maximum framerate at 30 FPS
         writeBChan chan Frame
 
       -- Run the app.


### PR DESCRIPTION
#47 reduced the maximum framerate to 60 FPS, which helped with CPU usage when the game is idle.  I propose to lower the cap further, to 30 FPS.  There is a reason movies run at 30 FPS.  I know some games run at higher rates than that, and probably it is possible to tell the difference---a game with nice graphics running at 60 FPS probably "feels smoother" than one running at 30.  However, "nice graphics" and "smooth" definitely are not words to describe an ASCII art simulation.  So I am highly skeptical that anyone would be able to tell the difference between running Swarm at 30 FPS or at something higher.  Besides, on my machine at least, when there are robots actively doing stuff and the screen has to be redrawn every frame, performance degrades to about 20 FPS anyway.

@TristanCacqueray , @HuwCampbell , would be interested to hear your feedback!