### PR TITLE
Enable bracketed paste mode to resolve #41

### DIFF
--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -18,7 +18,6 @@ import           Control.Concurrent   (forkIO, threadDelay)
 
 import           Brick
 import           Brick.BChan
-import           Brick.Main
 import qualified Graphics.Vty         as V
 
 import           Control.Monad.Except


### PR DESCRIPTION
Tested this out in my environment (MacOS & kitty terminal) and it worked great! Very noticeable lag when pasting full sentences is now gone completely.

Closes #41. Happy to make any changes, however small/stylistic.