### PR TITLE
Reset the needsRedraw only once per frame

### DIFF
--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -68,12 +68,6 @@ evalStepsPerTick = 100
 --   from a file when the whole program starts up).
 gameTick :: (MonadState GameState m, MonadIO m) => m ()
 gameTick = do
-
-  -- Reset the needsRedraw flag.  While stepping the robots, the flag will
-  -- get set to true if anything changes that requires redrawing the
-  -- world (e.g. a robot moving or disappearing).
-  needsRedraw .= False
-
   -- Note, it is tempting to do the below in one line with some clever
   -- lens combinator, but it's not possible.  We want to do an
   -- effectful traversal over a piece of the state (i.e. step each

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -137,6 +137,10 @@ runFrameUI s = do
 -- | Run the game for a single frame, without updating the UI.
 runFrame :: StateT AppState (EventM Name) ()
 runFrame = do
+  -- Reset the needsRedraw flag.  While procssing the frame and stepping the robots,
+  -- the flag will get set to true if anything changes that requires redrawing the
+  -- world (e.g. a robot moving or disappearing).
+  gameState . needsRedraw .= False
 
   -- The logic here is taken from https://gafferongames.com/post/fix_your_timestep/ .
 


### PR DESCRIPTION
When multiple ticks happen per frame, the needsRedraw should only be reset once per frame to avoid skipping update if the last tick does not need update.