### PR TITLE
Persist the inventory of the last robot viewed

### DIFF
--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -70,8 +70,8 @@ import           Swarm.Util
 -- | The 'ViewCenterRule' specifies how to determine the center of the
 --   world viewport.
 data ViewCenterRule
-  = VCLocation (V2 Int64)   -- ^ The view should be centered on an absolute position.
-  | VCRobot Text            -- ^ The view should be centered on a certain robot.
+  = VCLocation (V2 Int64) Text  -- ^ The view should be centered on an absolute position. Keeping the last robot viewed
+  | VCRobot Text                -- ^ The view should be centered on a certain robot.
   deriving (Eq, Ord, Show)
 
 makePrisms ''ViewCenterRule
@@ -171,7 +171,7 @@ messageQueue :: Lens' GameState [Text]
 --   is @Maybe@ because the rule may refer to a robot which does not
 --   exist.
 applyViewCenterRule :: ViewCenterRule -> Map Text Robot -> Maybe (V2 Int64)
-applyViewCenterRule (VCLocation l) _ = Just l
+applyViewCenterRule (VCLocation l _) _ = Just l
 applyViewCenterRule (VCRobot name) m = m ^? at name . _Just . robotLocation
 
 -- | Recalculate the veiw center (and cache the result in the
@@ -190,12 +190,12 @@ recalcViewCenter g = g
 -- | Modify the 'viewCenter' by applying an arbitrary function to the
 --   current value.  Note that this also modifies the 'viewCenterRule'
 --   to match.  After calling this function the 'viewCenterRule' will
---   specify a particular location, not a robot.
+--   specify a particular location, and the last viewed robot
 modifyViewCenter :: (V2 Int64 -> V2 Int64) -> GameState -> GameState
 modifyViewCenter update g = g
   & case g ^. viewCenterRule of
-      VCLocation l -> viewCenterRule .~ VCLocation (update l)
-      VCRobot _    -> viewCenterRule .~ VCLocation (update (g ^. viewCenter))
+      VCLocation l name -> viewCenterRule .~ VCLocation (update l) name
+      VCRobot name    -> viewCenterRule .~ VCLocation (update (g ^. viewCenter)) name
   & recalcViewCenter
 
 -- | Given a width and height, compute the region, centered on the
@@ -212,7 +212,10 @@ viewingRegion g (w,h) = (W.Coords (rmin,cmin), W.Coords (rmax,cmax))
 --   'viewCenterRule', if any.
 focusedRobot :: GameState -> Maybe Robot
 focusedRobot g = do
-  focusedRobotName <- g ^? viewCenterRule . _VCRobot
+  let focusedRobotName = 
+        case g ^. viewCenterRule of
+          VCLocation v2 name -> name
+          VCRobot name       -> name
   g ^? robotMap . ix focusedRobotName
 
 -- | Given a 'Robot', possibly modify its name to ensure that the name

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -29,6 +29,7 @@ module Swarm.Game.State
   , entityMap, recipesOut, recipesIn, world
   , viewCenterRule, viewCenter
   , needsRedraw, replStatus, messageQueue
+  , focusedRobotName
 
     -- * Utilities
 
@@ -99,19 +100,20 @@ data REPLStatus
 --   distinct from the UI).  See the lenses below for access to its
 --   fields.
 data GameState = GameState
-  { _gameMode       :: GameMode
-  , _paused         :: Bool
-  , _robotMap       :: Map Text Robot
-  , _gensym         :: Int
-  , _entityMap      :: EntityMap
-  , _recipesOut     :: IntMap [Recipe Entity]
-  , _recipesIn      :: IntMap [Recipe Entity]
-  , _world          :: W.World Int Entity
-  , _viewCenterRule :: ViewCenterRule
-  , _viewCenter     :: V2 Int64
-  , _needsRedraw    :: Bool
-  , _replStatus     :: REPLStatus
-  , _messageQueue   :: [Text]
+  { _gameMode         :: GameMode
+  , _paused           :: Bool
+  , _robotMap         :: Map Text Robot
+  , _gensym           :: Int
+  , _entityMap        :: EntityMap
+  , _recipesOut       :: IntMap [Recipe Entity]
+  , _recipesIn        :: IntMap [Recipe Entity]
+  , _world            :: W.World Int Entity
+  , _viewCenterRule   :: ViewCenterRule
+  , _viewCenter       :: V2 Int64
+  , _needsRedraw      :: Bool
+  , _replStatus       :: REPLStatus
+  , _messageQueue     :: [Text]
+  , _focusedRobotName :: Text
   }
 
 let exclude = ['_viewCenter] in
@@ -166,6 +168,9 @@ replStatus :: Lens' GameState REPLStatus
 -- | A queue of global messages.
 messageQueue :: Lens' GameState [Text]
 
+-- | The current robot in focus
+focusedRobotName :: Lens' GameState Text
+
 -- | Given a current mapping from robot names to robots, apply a
 --   'ViewCenterRule' to derive the location it refers to.  The result
 --   is @Maybe@ because the rule may refer to a robot which does not
@@ -211,9 +216,7 @@ viewingRegion g (w,h) = (W.Coords (rmin,cmin), W.Coords (rmax,cmax))
 -- | Find out which robot is currently specified by the
 --   'viewCenterRule', if any.
 focusedRobot :: GameState -> Maybe Robot
-focusedRobot g = do
-  focusedRobotName <- g ^? viewCenterRule . _VCRobot
-  g ^? robotMap . ix focusedRobotName
+focusedRobot g = g ^? robotMap . ix (g ^. focusedRobotName)
 
 -- | Given a 'Robot', possibly modify its name to ensure that the name
 --   is unique among robots.  This is done simply by appending a new unique
@@ -259,21 +262,24 @@ initGameState = do
         ]
       baseDevices = mapMaybe (`lookupEntityName` entities) baseDeviceNames
 
+  let baseName = "base"
+
   return $ GameState
     { _gameMode       = Classic
     , _paused         = False
-    , _robotMap       = M.singleton "base" (baseRobot baseDevices)
+    , _robotMap       = M.singleton baseName (baseRobot baseDevices)
     , _gensym         = 0
     , _entityMap      = entities
     , _recipesOut     = outRecipeMap recipes
     , _recipesIn      = inRecipeMap recipes
     , _world          =
       W.newWorld . fmap ((lkup entities <$>) . first fromEnum) . findGoodOrigin $ testWorld2
-    , _viewCenterRule = VCRobot "base"
+    , _viewCenterRule = VCRobot baseName
     , _viewCenter     = V2 0 0
     , _needsRedraw    = False
     , _replStatus     = REPLDone
     , _messageQueue   = []
+    , _focusedRobotName = baseName
     }
   where
     lkup :: EntityMap -> Maybe Text -> Maybe Entity

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -645,6 +645,8 @@ execConst c vs k = do
           (`isJustOr` cmdExn View [ "There is no robot named ", s, " to view." ])
 
         lift . lift $ viewCenterRule .= VCRobot s
+        lift . lift $ focusedRobotName .= s
+
         return $ Out VUnit k
       _ -> badConst
 

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -645,7 +645,6 @@ execConst c vs k = do
           (`isJustOr` cmdExn View [ "There is no robot named ", s, " to view." ])
 
         lift . lift $ viewCenterRule .= VCRobot s
-        lift . lift $ focusedRobotName .= s
 
         return $ Out VUnit k
       _ -> badConst

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -395,6 +395,7 @@ handleWorldEvent s (VtyEvent (V.EvKey k []))
 handleWorldEvent s (VtyEvent (V.EvKey (V.KChar 'c') [])) = do
   invalidateCacheEntry WorldCache
   continue $ s & gameState . viewCenterRule .~ VCRobot "base"
+               & gameState . focusedRobotName .~ "base"
                & gameState %~ recalcViewCenter
 
 -- pausing and stepping

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -395,8 +395,6 @@ handleWorldEvent s (VtyEvent (V.EvKey k []))
 handleWorldEvent s (VtyEvent (V.EvKey (V.KChar 'c') [])) = do
   invalidateCacheEntry WorldCache
   continue $ s & gameState . viewCenterRule .~ VCRobot "base"
-               & gameState . focusedRobotName .~ "base"
-               & gameState %~ recalcViewCenter
 
 -- pausing and stepping
 handleWorldEvent s (VtyEvent (V.EvKey (V.KChar 'p') [])) = do


### PR DESCRIPTION
Fixes #61 

Changes are fairly straightfoward. Just adds an extra field to `VCLocation` constructor with the name of the last robot viewed. The name of the robot is passed on `modifyViewCenter` function.