### PR TITLE
Add mergify configuration

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -18,6 +18,8 @@ on:
   - pull_request
 jobs:
   linux:
+    # when changing the name or adding ghc version, please don't forget to update
+    # the .mergify.yml rules at the root of the project.
     name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-18.04
     container:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+- actions:
+    merge:
+      strict: smart
+      method: squash
+  name: Automatically merge pull requests
+  conditions:
+  - check-success=Haskell-CI - Linux - GHC 9.0.1
+  - check-success=Haskell-CI - Linux - GHC 8.10.4
+  - label=merge me
+  - ! '#approved-reviews-by>=1'
+  - ! '#changes-requested-reviews-by=0'
+- actions:
+    delete_head_branch: {}
+  name: Delete head branch after merge
+  conditions:
+  - merged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,3 +221,5 @@ Having push access also means, of course, that you can push directly to
 improvements, and the like; for larger fixes, new features, _etc._ opening a
 pull request from a feature branch is still preferred, to give a chance for
 others to offer suggestions for improvement.
+
+To merge a PR, use the `merge me` label to trigger the mergify process.


### PR DESCRIPTION
This change configures the mergify bot so that:
- PR are validated with the tip of the project before merge
  to prevent incompatible PRs to be merged at once which could
  break the CI.
- PR maintainer uses a consistent smart squash workflow