### PR TITLE
Configure squash commit message to use title+body

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     merge:
       strict: smart
       method: squash
+      commit_message: title+body
   name: Automatically merge pull requests
   conditions:
   - check-success=Haskell-CI - Linux - GHC 9.0.1


### PR DESCRIPTION
This change should improve the commit history by using the PR title+body instead of the individual commits.