### PR TITLE
add an `install` command

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -249,7 +249,7 @@
     char: '<'
   description:
   - A grabber arm allows a robot to manipulate items via the 'grab',
-    'place', and 'give' commands.
+    'place', 'give', and 'install' commands.
   - The 'grab' command takes no arguments; it simply grabs whatever is
     available, and also returns the name of the grabbed thing as a string.
     It raises an exception if run in a cell that does not contain an item.
@@ -260,8 +260,11 @@
   - "The 'give' command takes two arguments: the name of the robot to
     give an item to (which can be at most 1 cell away), and the name
     of the item to give. Raises an exception if the operation fails."
+  - "The 'install' command takes two arguments: the name of the robot
+    on which to install a device (which can be at most 1 cell away),
+    and the name of the device to install."
 
-  capabilities: [grab, give, place]
+  capabilities: [grab, give, place, install]
   properties: [portable]
 
 - name: solar panel

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -20,7 +20,7 @@ module Swarm.Game.Robot
 
     -- ** Lenses
   , robotEntity, robotName, robotDisplay, robotLocation, robotOrientation, robotInventory
-  , installedDevices, robotCapabilities
+  , installedDevices, inventoryHash, robotCapabilities
   , robotCtx, robotEnv, machine, systemRobot, selfDestruct, tickSteps
 
     -- ** Create
@@ -40,6 +40,7 @@ import           Data.Set.Lens             (setOf)
 import           Data.Text                 (Text)
 import           Linear
 
+import           Data.Hashable             (hashWithSalt)
 import           Swarm.Game.CEK
 import           Swarm.Game.Display
 import           Swarm.Game.Entity         hiding (empty)
@@ -124,6 +125,12 @@ installedDevices = lens _installedDevices setInstalled
       r { _installedDevices  = inst
         , _robotCapabilities = inventoryCapabilities inst
         }
+
+-- | A hash of a robot's entity record and installed devices, to
+--   facilitate quickly deciding whether we need to redraw the robot
+--   info panel.
+inventoryHash :: Getter Robot Int
+inventoryHash = to (\r -> 17 `hashWithSalt` (r ^. (robotEntity . entityHash)) `hashWithSalt` (r ^. installedDevices))
 
 -- | Recompute the set of capabilities provided by the inventory of
 --   installed devices.

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -50,6 +50,7 @@ data Capability
   | CGrab         -- ^ Execute the 'Grab' command
   | CPlace        -- ^ Execute the 'Place' command
   | CGive         -- ^ Execute the 'Give' command
+  | CInstall      -- ^ Execute the 'Install' command
   | CMake         -- ^ Execute the 'Make' command
   | CBuild        -- ^ Execute the 'Build' command
   | CSenseloc     -- ^ Execute the 'GetX' and 'GetY' commands
@@ -224,6 +225,7 @@ constCaps Turn         = S.singleton CTurn
 constCaps Grab         = S.singleton CGrab
 constCaps Place        = S.singleton CPlace
 constCaps Give         = S.singleton CGive
+constCaps Install      = S.singleton CInstall
 constCaps Make         = S.singleton CMake
 constCaps If           = S.singleton CCond
 constCaps Create       = S.singleton CCreate

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -179,6 +179,7 @@ parseConst =
   <|> Grab    <$ reserved "grab"
   <|> Place   <$ reserved "place"
   <|> Give    <$ reserved "give"
+  <|> Install <$ reserved "install"
   <|> Make    <$ reserved "make"
   <|> Build   <$ reserved "build"
   <|> Run     <$ reserved "run"

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -133,6 +133,7 @@ data Const
   | Grab              -- ^ Grab an item from the current location.
   | Place             -- ^ Try to place an item at the current location.
   | Give              -- ^ Give an item to another robot at the current location.
+  | Install           -- ^ Install a device on a robot.
   | Make              -- ^ Make an item.
   | Build             -- ^ Construct a new robot.
   | Say               -- ^ Emit a message.
@@ -189,6 +190,7 @@ arity Turn         = 1
 arity Grab         = 0
 arity Place        = 1
 arity Give         = 2
+arity Install      = 2
 arity Make         = 1
 arity Build        = 2
 arity Say          = 1

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -414,6 +414,7 @@ inferConst c = toU $ case c of
   Grab         -> [tyQ| cmd string |]
   Place        -> [tyQ| string -> cmd () |]
   Give         -> [tyQ| string -> string -> cmd () |]
+  Install      -> [tyQ| string -> string -> cmd () |]
   Make         -> [tyQ| string -> cmd () |]
   Build        -> [tyQ| forall a. string -> cmd a -> cmd string |]
   Say          -> [tyQ| string -> cmd () |]

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -284,14 +284,14 @@ updateUI = do
     -- The hash of the robot whose inventory is currently displayed (if any)
 
   fr <- use (gameState . to focusedRobot)
-  let focusedRobotHash = view (robotEntity . entityHash) <$> fr
+  let focusedRobotHash = view inventoryHash <$> fr
     -- The hash of the focused robot (if any)
 
   -- If the hashes don't match (either because which robot (or
   -- whether any robot) is focused changed, or the focused robot's
   -- inventory changed), regenerate the list.
   inventoryUpdated <-
-    if (listRobotHash /= focusedRobotHash)
+    if listRobotHash /= focusedRobotHash
       then do
         zoom uiState $ populateInventoryList fr
         pure True

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -310,7 +310,7 @@ populateInventoryList (Just r) = do
 
   -- Finally, populate the newly created list in the UI, and remember
   -- the hash of the current robot.
-  uiInventory .= Just (r ^. robotEntity . entityHash, lst)
+  uiInventory .= Just (r ^. inventoryHash, lst)
 
 ------------------------------------------------------------
 -- App state (= UI state + game state)


### PR DESCRIPTION
Closes #92.  See the discussion on that issue for more context.

* Handle self-installation specially
* The robot entity hash didn't include the installed devices before;
  fix it so the inventory display updates properly when the installed
  devices are modified
* Flag a UI redraw iff one of the robots involved is currently focused