### PR TITLE
Add cabal to HLS configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist-newstyle/
 TAGS
 
+cabal.project.local
+hie.yaml
+
 .stack-work/
 stack.yaml.lock
 .hie/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,11 @@ already comfortable contributing to open source, you can skip to the [Convention
    rather than working in your own fork. For more information, see
    [I have push access to the Swarm repository, now what?](#i-have-push-access-to-the-swarm-repository-now-what).
 
+As a note, if you want to use the Stack tool with [HLS](https://github.com/haskell/haskell-language-server),
+check the `hie.yaml.stack` file. Pure Cabal should work fine with the defaults,
+but you might want to [add a GHC flag](https://haskell-language-server.readthedocs.io/en/latest/features.html)
+to build docs into `cabal.project.local`.
+
 ### Conventions
 
 We follow a few conventions to help keep everyone on the same page.

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,2 +1,0 @@
-cradle:
-  stack:

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -1,0 +1,10 @@
+-- If you want to use HLS with Stack, simply do
+--
+--   cp hie.yaml.stack hie.yaml
+--
+-- the file hie.yaml is ignored, so it will not
+-- show in git status ;)
+--
+-- If you are using Cabal, you can ignore this file.
+cradle:
+  stack:


### PR DESCRIPTION
- allow HLS to use Cabal instead of Stack
  - Cabal works fine, and I do not see any advantage to using Stack
  - someone using Stack should test this does not switch him to Cabal :warning:  
- ignore `cabal.project.local` so I can put there `ghc-options: -haddock`
  - this flag could lead to errors before GHC 9, but it gives me [docs on hover](https://haskell-language-server.readthedocs.io/en/latest/features.html)
