### PR TITLE
Add noop keyword

### DIFF
--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -70,7 +70,7 @@ type ParserError = ParseErrorBundle Text Void
 reservedWords :: [String]
 reservedWords =
   [ "left", "right", "back", "forward", "north", "south", "east", "west", "down"
-  , "wait", "selfdestruct", "move", "turn", "grab", "place", "give", "make"
+  , "wait", "noop", "selfdestruct", "move", "turn", "grab", "place", "give", "make"
   , "build", "run", "getx", "gety", "scan", "upload", "blocked"
   , "random", "say", "view", "appear", "create", "ishere"
   , "int", "string", "dir", "bool", "cmd"

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -237,7 +237,7 @@ isCmd c = case constMeta $ constInfo c of
 -- | Function constants user can call with reserved words ('wait',...).
 isUserFunc :: Const -> Bool
 isUserFunc c = case constMeta $ constInfo c of
-  ConstMFunc {} -> c `notElem` [Noop, Force]
+  ConstMFunc {} -> c /= Force
   _ -> False
 
 -- | Information about constants used in parsing and pretty printing.
@@ -248,7 +248,7 @@ isUserFunc c = case constMeta $ constInfo c of
 constInfo :: Const -> ConstInfo
 constInfo c = case c of
   Wait         -> commandLow 0
-  Noop         -> command "{}" 0
+  Noop         -> commandLow 0
   Selfdestruct -> commandLow 0
   Move         -> commandLow 0
   Turn         -> commandLow 1


### PR DESCRIPTION
Adds noop keyword to the player-facing language. Previous syntax
(`{}`) is retained.  Only parsing of the language is affected, the
representation remains the same regardless of which syntax was used.
The new keyword is now the canonical version of the command, used in
pretty-printing and the like.

Fixes #101

I'm not certain about which syntax to use for the syntax info.  I decided to
go with the new `noop` keyword instead of the old `{}` because it is more
explicit and clearer.