### PR TITLE
Compatibility with hashable-1.3.4

### DIFF
--- a/src/Swarm/Game/Display.hs
+++ b/src/Swarm/Game/Display.hs
@@ -57,8 +57,6 @@ type Priority = Int
 
 -- Some orphan instances we need to be able to derive a Hashable
 -- instance for Display
-instance (Hashable k, Hashable v) => Hashable (Map k v) where
-  hashWithSalt = hashUsing M.assocs
 instance Hashable AttrName
 
 -- | A record explaining how to display an entity in the TUI.

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: lts-18.12
 extra-deps:
 - brick-0.64
 - word-wrap-0.5
+- hashable-1.3.4.0
 - git: https://github.com/colinhect/hsnoise
   commit: 4ccff11dea7e8d94e6a5fcaf8f43857bd65bd72d
 # get latest th-extras for ghc-9.0.1 compat

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -95,7 +95,7 @@ library
                       containers                    >= 0.6.2 && < 0.7,
                       directory                     >= 1.3 && < 1.4,
                       either                        >= 5.0 && < 5.1,
-                      hashable                      >= 1.3 && < 1.4,
+                      hashable                      >= 1.3.4 && < 1.4,
                       megaparsec                    >= 9.0 && < 9.2,
                       hsnoise                       >= 0.0.2 && < 0.1,
                       lens                          >= 4.19 && < 5.1,


### PR DESCRIPTION
The code has an orphan instance `Hashable (Map k v)` but, starting from [hashable-1.3.4.0](https://hackage.haskell.org/package/hashable-1.3.4.0/docs/Data-Hashable.html#t:Hashable), that instance already exists in hashable itself, making compilation fail.

I disabled it for that case using a CPP directive.