### PR TITLE
bug fix: byName out of sync with counts due to case insensitivity.

### DIFF
--- a/src/Swarm/Game/Entity.hs
+++ b/src/Swarm/Game/Entity.hs
@@ -531,7 +531,7 @@ deleteCount k e (Inventory cs byN) = Inventory cs' byN'
   newCount = lookup e (Inventory cs' byN)
 
   byN'
-    | newCount == 0 = M.adjust (IS.delete (e ^. entityHash)) (e ^. entityName) byN
+    | newCount == 0 = M.adjust (IS.delete (e ^. entityHash)) (T.toLower $ e ^. entityName) byN
     | otherwise = byN
 
   removeCount :: Maybe (Count, a) -> Maybe (Count, a)
@@ -545,7 +545,7 @@ deleteAll :: Entity -> Inventory -> Inventory
 deleteAll e (Inventory cs byN) =
   Inventory
     (IM.alter (const Nothing) (e ^. entityHash) cs)
-    (M.adjust (IS.delete (e ^. entityHash)) (e ^. entityName) byN)
+    (M.adjust (IS.delete (e ^. entityHash)) (T.toLower $ e ^. entityName) byN)
 
 -- | Get the entities in an inventory and their associated counts.
 elems :: Inventory -> [(Count, Entity)]

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -145,6 +145,7 @@ test-suite swarm-unit
                       tasty-hunit                   >= 0.10 && < 0.11,
                       -- Import shared with the library don't need bounds
                       base,
+                      lens,
                       swarm,
                       text
 

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -14,8 +14,8 @@ import Swarm.Language.Pipeline
 import Swarm.Language.Pretty
 import Swarm.Language.Syntax hiding (mkOp)
 
-import qualified Swarm.Game.Entity as E
 import Swarm.Game.Display (defaultRobotDisplay)
+import qualified Swarm.Game.Entity as E
 
 main :: IO ()
 main = defaultMain tests
@@ -132,10 +132,10 @@ prettyConst =
   equalPretty expected term = assertEqual "" expected . show $ ppr term
 
 inventory :: TestTree
-inventory = testGroup
+inventory =
+  testGroup
     "Inventory"
     [ testCase "byName case insensitive insert delete" $
         let e = E.mkEntity defaultRobotDisplay "WaCkYcAsE" [] []
-        in  assertEqual "" (E.empty & E.insert e & E.delete e & E.lookupByName (e ^. E.entityName)) []
+         in assertEqual "" (E.empty & E.insert e & E.delete e & E.lookupByName (e ^. E.entityName)) []
     ]
-  

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -3,6 +3,8 @@
 -- | Swarm unit tests
 module Main where
 
+import Control.Lens
+
 import Data.Text (Text)
 import qualified Data.Text as T
 import Test.Tasty
@@ -12,11 +14,14 @@ import Swarm.Language.Pipeline
 import Swarm.Language.Pretty
 import Swarm.Language.Syntax hiding (mkOp)
 
+import qualified Swarm.Game.Entity as E
+import Swarm.Game.Display (defaultRobotDisplay)
+
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Tests" [parser, prettyConst]
+tests = testGroup "Tests" [parser, prettyConst, inventory]
 
 parser :: TestTree
 parser =
@@ -125,3 +130,12 @@ prettyConst =
  where
   equalPretty :: String -> Term -> Assertion
   equalPretty expected term = assertEqual "" expected . show $ ppr term
+
+inventory :: TestTree
+inventory = testGroup
+    "Inventory"
+    [ testCase "byName case insensitive insert delete" $
+        let e = E.mkEntity defaultRobotDisplay "WaCkYcAsE" [] []
+        in  assertEqual "" (E.empty & E.insert e & E.delete e & E.lookupByName (e ^. E.entityName)) []
+    ]
+  


### PR DESCRIPTION
The `Inventory` `counts` and `byName` maps could get out of sync due to missing case insensitivity on deletion.  Perhaps a better fix would be to use something like [https://hackage.haskell.org/package/case-insensitive](https://hackage.haskell.org/package/case-insensitive).