### PR TITLE
advertise ctrl-c to cancel base computation

### DIFF
--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -37,6 +37,7 @@ module Swarm.Game.State (
   viewCenter,
   needsRedraw,
   replStatus,
+  replWorking,
   messageQueue,
   focusedRobotName,
 
@@ -208,6 +209,13 @@ needsRedraw :: Lens' GameState Bool
 
 -- | The current status of the REPL.
 replStatus :: Lens' GameState REPLStatus
+
+-- | Whether the repl is currently working.
+replWorking :: Getter GameState Bool
+replWorking = to (\s -> matchesWorking $ s ^. replStatus)
+ where
+  matchesWorking REPLDone = False
+  matchesWorking (REPLWorking _ _) = True
 
 -- | A queue of global messages.
 messageQueue :: Lens' GameState [Text]

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -95,6 +95,7 @@ drawUI s =
                 (plainBorder & bottomLabels . rightLabel ?~ padLeftRight 1 (drawTPS s))
                 (drawWorld $ s ^. gameState)
             , drawMenu
+                (s ^. gameState . replWorking)
                 (s ^. gameState . paused)
                 ((s ^. gameState . viewCenterRule) == VCRobot "base")
                 (s ^. gameState . gameMode)
@@ -214,8 +215,8 @@ drawDialog s = case s ^. uiModal of
 -- | Draw a menu explaining what key commands are available for the
 --   current panel.  This menu is displayed as a single line in
 --   between the world panel and the REPL.
-drawMenu :: Bool -> Bool -> GameMode -> UIState -> Widget Name
-drawMenu isPaused viewingBase mode =
+drawMenu :: Bool -> Bool -> Bool -> GameMode -> UIState -> Widget Name
+drawMenu isReplWorking isPaused viewingBase mode =
   vLimit 1
     . hBox
     . (++ [gameModeWidget])
@@ -238,8 +239,9 @@ drawMenu isPaused viewingBase mode =
     ]
   keyCmdsFor (Just REPLPanel) =
     [ ("↓↑", "history")
-    , ("Enter", "execute")
     ]
+      ++ [("Enter", "execute") | not isReplWorking]
+      ++ [("^c", "cancel") | isReplWorking]
   keyCmdsFor (Just WorldPanel) =
     [ ("←↓↑→ / hjkl", "scroll")
     , ("<>", "slower/faster")


### PR DESCRIPTION
While the repl is actively working, the ``[Enter] execute`` hint in the key menu will now be replaced by ``[^c] cancel``. 

Fixes #44 