### PR TITLE
Add robot self naming capability

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -404,3 +404,14 @@
     knowledge to another nearby robot; for example, 'upload \"base\"'."
   properties: [portable]
   capabilities: [scan, sensefront]
+
+- name: mirror
+  display:
+    attr: device
+    char: 'U'
+  description:
+  - "With a mirror, robots can reflect on themselves and see their own name"
+  - "A mirror enables the `self` command which returns the calling robots
+     name as text"
+  properities: [portable]
+  capabilities: [self]

--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -774,6 +774,11 @@ execConst c vs k = do
           Nothing -> return $ Out (VBool False) k
           Just e -> return $ Out (VBool (T.toLower (e ^. entityName) == T.toLower s)) k
       _ -> badConst
+    Self -> case vs of
+      [] -> do
+        name <- use robotName
+        return $ Out (VString name) k
+      _ -> badConst
     Force -> case vs of
       [VDelay Nothing t e] -> return $ In t e k
       [VDelay (Just x) t e] -> return $ In t (addBinding x (VDelay (Just x) t e) e) k

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -87,6 +87,8 @@ data Capability
     CLambda
   | -- | Enable recursive definitions
     CRecursion
+  | -- | Capability to introspect and see it's own name
+    CSelf
   deriving (Eq, Ord, Show, Read, Enum, Bounded, Generic, Hashable, Data)
 
 instance ToJSON Capability where
@@ -272,6 +274,7 @@ constCaps Exp = S.singleton CArith
 -- currently don't.
 constCaps View = S.empty -- XXX this should also require something.
 constCaps Ishere = S.empty -- XXX this should require a capability.
+constCaps Self = S.singleton CSelf
 constCaps Run = S.empty -- XXX this should also require a capability
 -- which the base starts out with.
 constCaps Not = S.empty -- XXX some kind of boolean logic cap?

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -201,6 +201,8 @@ data Const
     Upload
   | -- | See if a specific entity is here. (This may be removed.)
     Ishere
+  | -- | Find it's own name
+    Self
   | -- | Get a uniformly random integer.
     Random
   | -- Modules
@@ -344,6 +346,7 @@ constInfo c = case c of
   Scan -> commandLow 0
   Upload -> commandLow 1
   Ishere -> commandLow 1
+  Self   -> commandLow 0
   Random -> commandLow 1
   Run -> commandLow 1
   Return -> commandLow 1
@@ -371,6 +374,7 @@ constInfo c = case c of
   binaryOp s p side = ConstInfo {syntax = s, fixity = p, constMeta = ConstMBinOp side}
   command s a = ConstInfo {syntax = s, fixity = 11, constMeta = ConstMFunc a True}
   function s a = ConstInfo {syntax = s, fixity = 11, constMeta = ConstMFunc a False}
+  -- takes the number of arguments for a commmand
   commandLow = command (lowShow c)
   functionLow = function (lowShow c)
 

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -433,6 +433,7 @@ inferConst c = toU $ case c of
   Scan -> [tyQ| dir -> cmd () |]
   Upload -> [tyQ| string -> cmd () |]
   Ishere -> [tyQ| string -> cmd bool |]
+  Self -> [tyQ| cmd string |]
   Random -> [tyQ| int -> cmd int |]
   Run -> [tyQ| string -> cmd () |]
   If -> [tyQ| forall a. bool -> a -> a -> a |]


### PR DESCRIPTION
Adds the following -
* `mirror` entity that adds `self` capability
* `self` returns a callee robot's name

I have added the names and description that I saw fit. Please recommend better names as you see fit.