### PR TITLE
REPL ignores Enter while working

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -339,20 +339,21 @@ handleREPLEvent s (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl])) =
     s
       & gameState . robotMap . ix "base" . machine .~ idleMachine
 handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
-  case processTerm' topCtx topCapCtx entry of
-    Right t@(ProcessedTerm _ (Module ty _) _ _) ->
-      continue $
-        s
-          & uiState . uiReplForm %~ updateFormState ""
-          & uiState . uiReplType .~ Nothing
-          & uiState . uiReplHistory %~ (REPLEntry True entry :)
-          & uiState . uiReplHistIdx .~ (-1)
-          & gameState . replStatus .~ REPLWorking ty Nothing
-          & gameState . robotMap . ix "base" . machine .~ initMachine t topEnv
-    Left err ->
-      continue $
-        s
-          & uiState . uiError ?~ txt err
+  continue $
+    if not $ s ^. gameState . replWorking
+      then case processTerm' topCtx topCapCtx entry of
+        Right t@(ProcessedTerm _ (Module ty _) _ _) ->
+          s
+            & uiState . uiReplForm %~ updateFormState ""
+            & uiState . uiReplType .~ Nothing
+            & uiState . uiReplHistory %~ (REPLEntry True entry :)
+            & uiState . uiReplHistIdx .~ (-1)
+            & gameState . replStatus .~ REPLWorking ty Nothing
+            & gameState . robotMap . ix "base" . machine .~ initMachine t topEnv
+        Left err ->
+          s
+            & uiState . uiError ?~ txt err
+      else s
  where
   -- XXX check that we have the capabilities needed to run the
   -- program before even starting?


### PR DESCRIPTION
When you hit Enter at the REPL the REPL event handler now checks whether the base is currently running a computation. If this is the case, then the Enter key event is ignored. 

Fixes #139 