### PR TITLE
Clear the error widget on successful REPL entry

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -339,21 +339,23 @@ handleREPLEvent s (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl])) =
     s
       & gameState . robotMap . ix "base" . machine .~ idleMachine
 handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
-  continue $
-    if not $ s ^. gameState . replWorking
-      then case processTerm' topCtx topCapCtx entry of
-        Right t@(ProcessedTerm _ (Module ty _) _ _) ->
+  if not $ s ^. gameState . replWorking
+    then case processTerm' topCtx topCapCtx entry of
+      Right t@(ProcessedTerm _ (Module ty _) _ _) ->
+        continue $
           s
             & uiState . uiReplForm %~ updateFormState ""
             & uiState . uiReplType .~ Nothing
             & uiState . uiReplHistory %~ (REPLEntry True entry :)
             & uiState . uiReplHistIdx .~ (-1)
+            & uiState . uiError .~ Nothing
             & gameState . replStatus .~ REPLWorking ty Nothing
             & gameState . robotMap . ix "base" . machine .~ initMachine t topEnv
-        Left err ->
+      Left err ->
+        continue $
           s
             & uiState . uiError ?~ txt err
-      else s
+    else continueWithoutRedraw s
  where
   -- XXX check that we have the capabilities needed to run the
   -- program before even starting?


### PR DESCRIPTION
This pull request combines two changes:

1. When the user hits "Enter" in the REPL and the entry is validated, any previous error is removed from the screen.
2. When the user hits "Enter" while the base is actively running a computation, this is ignored now without triggering a redraw. This change is based on the review comment https://github.com/byorgey/swarm/pull/181#pullrequestreview-770727562 . While using ``continueWithoutRedraw`` for this case is more verbose than factoring out ``continue`` as I did before and the performance impact is most certainly negligible, I think that this solution is semantically cleaner. Of course I am happy to roll back this change if there is a disagreement about this point. 

Closes #76 