### PR TITLE
cap maximum ticks per frame at 30

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -237,20 +237,28 @@ runFrame = do
   uiState . frameCount += 1
 
   -- Now do as many ticks as we need to catch up.
+  uiState . frameTickCount .= 0
   runFrameTicks (fromNanoSecs dt)
 
+ticksPerFrameCap :: Int
+ticksPerFrameCap = 30
+
 -- | Do zero or more ticks, with each tick notionally taking the given
---   timestep, until we have used up all available accumulated time.
+--   timestep, until we have used up all available accumulated time,
+--   OR until we have hit the cap on ticks per frame, whichever comes
+--   first.
 runFrameTicks :: TimeSpec -> StateT AppState (EventM Name) ()
 runFrameTicks dt = do
   a <- use (uiState . accumulatedTime)
+  t <- use (uiState . frameTickCount)
 
-  -- Is there still time left?
-  when (a >= dt) $ do
+  -- Is there still time left?  Or have we hit the cap on ticks per frame?
+  when (a >= dt && t < ticksPerFrameCap) $ do
     -- If so, do a tick, count it, subtract dt from the accumulated time,
     -- and loop!
     runGameTick
     uiState . tickCount += 1
+    uiState . frameTickCount += 1
     uiState . accumulatedTime -= dt
     runFrameTicks dt
 

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -45,6 +45,7 @@ module Swarm.TUI.Model (
   accumulatedTime,
   tickCount,
   frameCount,
+  frameTickCount,
   lastInfoTime,
   uiShowFPS,
   uiTPF,
@@ -191,6 +192,7 @@ data UIState = UIState
   , _lgTicksPerSecond :: Int
   , _tickCount :: Int
   , _frameCount :: Int
+  , _frameTickCount :: Int
   , _lastFrameTime :: TimeSpec
   , _accumulatedTime :: TimeSpec
   , _lastInfoTime :: TimeSpec
@@ -257,11 +259,17 @@ uiFPS :: Lens' UIState Double
 --   second.
 lgTicksPerSecond :: Lens' UIState Int
 
--- | A counter used to track how many ticks happen in a single frame.
+-- | A counter used to track how many ticks have happened since the
+--   last time we updated the ticks/frame statistics.
 tickCount :: Lens' UIState Int
 
--- | A counter used to track how many frame got rendered
+-- | A counter used to track how many frames have been rendered since the
+--   last time we updated the ticks/frame statistics.
 frameCount :: Lens' UIState Int
+
+-- | A counter used to track how many ticks have happened in the
+--   current frame, so we can stop when we get to the tick cap.
+frameTickCount :: Lens' UIState Int
 
 -- | The time of the last info widget update
 lastInfoTime :: Lens' UIState TimeSpec
@@ -326,6 +334,7 @@ initUIState = liftIO $ do
       , _lastInfoTime = 0
       , _tickCount = 0
       , _frameCount = 0
+      , _frameTickCount = 0
       }
 
 ------------------------------------------------------------


### PR DESCRIPTION
Cap the maximum number of ticks per frame (arbitrarily) at 30, to
prevent the "spiral of death" (see
https://gafferongames.com/post/fix_your_timestep/).

To see this in effect, go into Creative mode, crank up the ticks per
second to 32 or so, then (for suitable definitions of `repeat` and
`forever`) execute

`repeat 1000 { build "" {forever {move; turn left}}}`

Without this PR, it should eventually grind to a halt.  With this PR,
the game should keep running, though with lots of lag.

Closes #42 .