### PR TITLE
Delay type

### DIFF
--- a/contribs/swarm-mode.el
+++ b/contribs/swarm-mode.el
@@ -11,8 +11,53 @@
 
 (require 'lsp-mode)
 
+(defvar swarm-mode-syntax-table nil "Syntax table for `swarm-mode'.")
+
+(setq swarm-mode-syntax-table
+      (let ( (synTable (make-syntax-table)))
+
+        ;; C++ style comments “// …”
+        (modify-syntax-entry ?\/ ". 12b" synTable)
+        (modify-syntax-entry ?\n "> b" synTable)
+        ;; ;; Java style block comments “/* … */”
+        ;; not sure how to get these at the same time as single-line // comments
+        ;; (modify-syntax-entry ?\/ ". 14" synTable)
+        ;; (modify-syntax-entry ?* ". 23" synTable)
+
+        synTable))
+
+(setq swarm-font-lock-keywords
+      (let* (
+             ;; We should figure out how to autogenerate these, so we don't have
+             ;; to edit the emacs mode every time we add new commands.
+             (x-keywords '("def" "end"))
+             (x-builtins '("if" "run" "return" "try" "raise" "force" "fst" "snd"))
+             (x-commands
+              '("noop" "wait" "selfdestruct" "move" "turn" "grab" "place" "give"
+                "install" "make" "build" "salvage" "reprogram"
+                "say" "log" "view" "appear" "create" "getx" "gety"
+                "blocked" "scan" "upload" "ishere" "whoami"
+                "random" "not"
+                "left" "right" "back" "forward" "north" "south" "east" "west" "down"
+                ))
+             (x-types '("int" "string" "dir" "bool" "cmd"))
+
+             (x-keywords-regexp (regexp-opt x-keywords 'words))
+             (x-builtins-regexp (regexp-opt x-builtins 'words))
+             (x-commands-regexp (regexp-opt x-commands 'words))
+             (x-types-regexp (regexp-opt x-types 'words)))
+
+        `(
+          (,x-keywords-regexp . 'font-lock-keyword-face)
+          (,x-builtins-regexp . 'font-lock-builtin-face)
+          (,x-types-regexp . 'font-lock-type-face)
+          (,x-commands-regexp . 'font-lock-constant-face)
+          ("[a-z_][a-z0-9_]*" . 'font-lock-function-name-face)
+          )))
+
 (define-derived-mode swarm-mode prog-mode "Swarm Lang Mode"
-  (font-lock-fontify-buffer))
+  (setq font-lock-defaults '((swarm-font-lock-keywords) nil t nil))
+  (set-syntax-table swarm-mode-syntax-table))
 
 (add-to-list 'auto-mode-alist '("\\.sw\\'" . swarm-mode))
 
@@ -24,4 +69,6 @@
     (make-lsp-client :new-connection (lsp-stdio-connection (list "swarm" "lsp"))
                      :activation-fn (lsp-activate-on "swarm")
                      :server-id 'swarm-check)))
+
+(provide 'swarm-mode)
 ;;; swarm-mode.el ends here

--- a/src/Swarm/Language/Elaborate.hs
+++ b/src/Swarm/Language/Elaborate.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
------------------------------------------------------------------------------
-
------------------------------------------------------------------------------
-
 -- |
 -- Module      :  Swarm.Language.Elaborate
 -- Copyright   :  Brent Yorgey
@@ -51,15 +47,5 @@ elaborate =
   -- any such variables must in fact refer to things previously
   -- bound by 'def'.
   rewrite (TDef x ty t1) = TDef x ty (mapFree1 x (TApp (TConst Force)) t1)
-  -- Delay evaluation of the program argument to a 'Build' command,
-  -- so it will be evaluated by the constructed robot instead of the one
-  -- doing the constructing.
-  rewrite (TApp (TApp (TConst Build) nm) prog) =
-    TApp (TApp (TConst Build) nm) (TDelay prog)
-  -- Delay evaluation of the program argument to a 'Reprogram' command,
-  -- so it will be evaluated by the reprogrammed robot instead of the one
-  -- doing the reprogramming.
-  rewrite (TApp (TApp (TConst Reprogram) nm) prog) =
-    TApp (TApp (TConst Reprogram) nm) (TDelay prog)
   -- Leave any other subterms alone.
   rewrite t = t

--- a/src/Swarm/Language/Pretty.hs
+++ b/src/Swarm/Language/Pretty.hs
@@ -85,6 +85,7 @@ instance PrettyPrec t => PrettyPrec (TypeF t) where
     pparens (p > 2) $
       prettyPrec 3 ty1 <+> "*" <+> prettyPrec 2 ty2
   prettyPrec p (TyCmdF ty) = pparens (p > 9) $ "cmd" <+> prettyPrec 10 ty
+  prettyPrec p (TyDelayF ty) = pparens (p > 9) $ "delay" <+> prettyPrec 10 ty
   prettyPrec p (TyFunF ty1 ty2) =
     pparens (p > 0) $
       prettyPrec 1 ty1 <+> "->" <+> prettyPrec 0 ty2
@@ -126,7 +127,7 @@ instance PrettyPrec Term where
   prettyPrec _ (TAntiString v) = "$str:" <> pretty v
   prettyPrec _ (TBool b) = bool "false" "true" b
   prettyPrec _ (TVar s) = pretty s
-  prettyPrec p (TDelay t) = pparens (p > 10) $ "delay" <+> prettyPrec 11 t
+  prettyPrec _ (TDelay t) = braces . braces $ ppr t
   prettyPrec _ (TPair t1 t2) = pparens True $ ppr t1 <> "," <+> ppr t2
   prettyPrec _ (TLam x mty body) =
     "\\" <> pretty x <> maybe "" ((":" <>) . ppr) mty <> "." <+> ppr body

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -322,8 +322,8 @@ infer (Syntax _ (TAntiString _)) = return UTyString
 infer (Syntax _ (TBool _)) = return UTyBool
 -- To infer the type of a pair, just infer both components.
 infer (Syntax _ (SPair t1 t2)) = UTyProd <$> infer t1 <*> infer t2
--- delay t has the same type as t.
-infer (Syntax l (TDelay t)) = infer (Syntax l t)
+-- if t : ty, then  {{t}} : delay ty.
+infer (Syntax _ (SDelay t)) = UTyDelay <$> infer t
 -- Just look up variables in the context.
 infer (Syntax l (TVar x)) = lookup l x
 -- To infer the type of a lambda if the type of the argument is
@@ -425,8 +425,8 @@ inferConst c = toU $ case c of
   Give -> [tyQ| string -> string -> cmd () |]
   Install -> [tyQ| string -> string -> cmd () |]
   Make -> [tyQ| string -> cmd () |]
-  Reprogram -> [tyQ| forall a. string -> cmd a -> cmd () |]
-  Build -> [tyQ| forall a. string -> cmd a -> cmd string |]
+  Reprogram -> [tyQ| forall a. string -> delay (cmd a) -> cmd () |]
+  Build -> [tyQ| forall a. string -> delay (cmd a) -> cmd string |]
   Salvage -> [tyQ| cmd () |]
   Say -> [tyQ| string -> cmd () |]
   Log -> [tyQ| string -> cmd () |]
@@ -445,7 +445,7 @@ inferConst c = toU $ case c of
   If -> [tyQ| forall a. bool -> a -> a -> a |]
   Fst -> [tyQ| forall a b. a * b -> a |]
   Snd -> [tyQ| forall a b. a * b -> b |]
-  Force -> [tyQ| forall a. a -> a |]
+  Force -> [tyQ| forall a. delay a -> a |]
   Return -> [tyQ| forall a. a -> cmd a |]
   Try -> [tyQ| forall a. cmd a -> cmd a -> cmd a |]
   Raise -> [tyQ| forall a. string -> cmd a |]

--- a/src/Swarm/Language/Types.hs
+++ b/src/Swarm/Language/Types.hs
@@ -43,6 +43,7 @@ module Swarm.Language.Types (
   pattern (:*:),
   pattern (:->:),
   pattern TyCmd,
+  pattern TyDelay,
 
   -- * @UType@
   UType,
@@ -56,6 +57,7 @@ module Swarm.Language.Types (
   pattern UTyProd,
   pattern UTyFun,
   pattern UTyCmd,
+  pattern UTyDelay,
 
   -- ** Utilities
   ucata,
@@ -127,6 +129,8 @@ data TypeF t
   | -- | Commands, with return type.  Note that
     --   commands form a monad.
     TyCmdF t
+  | -- | Type of delayed computations.
+    TyDelayF t
   | -- | Product type.
     TyProdF t t
   | -- | Function type.
@@ -317,6 +321,9 @@ pattern ty1 :->: ty2 = Fix (TyFunF ty1 ty2)
 pattern TyCmd :: Type -> Type
 pattern TyCmd ty1 = Fix (TyCmdF ty1)
 
+pattern TyDelay :: Type -> Type
+pattern TyDelay ty1 = Fix (TyDelayF ty1)
+
 pattern UTyBase :: BaseTy -> UType
 pattern UTyBase b = UTerm (TyBaseF b)
 
@@ -346,3 +353,6 @@ pattern UTyFun ty1 ty2 = UTerm (TyFunF ty1 ty2)
 
 pattern UTyCmd :: UType -> UType
 pattern UTyCmd ty1 = UTerm (TyCmdF ty1)
+
+pattern UTyDelay :: UType -> UType
+pattern UTyDelay ty1 = UTerm (TyDelayF ty1)


### PR DESCRIPTION
Closes #150 .  The idea is to make explicit in the type system when evaluation of a computation should be delayed.  This gives the user fine-grained control over selective laziness (for example, once we have sum types and recursive types, one could use this to define lazy infinite data structures).  It also allows us to guarantee that certain commands such as `build` and `reprogram` delay evaluation of their arguments, and lets the user e.g. define their own modified versions of `build` without compromising those guarantees.

I'm very open to bikeshedding on the syntax.  I have initially chosen `{{ ... }}` to denote a delayed computation, and `! (...)` to denote forcing.  I think it's important to have nice-looking syntax for `delay` since the user is going to be typing it a lot.  I am more on the fence about whether we should have a prefix operator for forcing, or just use the word `force`.

- Add a new type constructor `delay`
- `TDelay` is now written with special double brackets `{{...}}`; `{{t}} : delay ty` whenever `t : ty`
- Add a special case to the parser: `{{}}` parses as `delay noop`
- `force : delay ty -> ty` is now written as a prefix `!`, e.g. `{{5}} : delay int` and `!{{5}} : int`
- change the types of `build` and `reprogram` to require a delayed program, e.g. `build : string -> delay (cmd a) -> cmd string`
- don't elaborate Build and Reprogram with extra Delay wrappers since one is now required by the type
