### PR TITLE
Test example `.sw` files to see if they type check

### DIFF
--- a/swarm.cabal
+++ b/swarm.cabal
@@ -138,17 +138,18 @@ executable swarm
 
 test-suite swarm-unit
     import:           stan-config, common
-    main-is:          Unit.hs
+    main-is:          Integration.hs
     type:             exitcode-stdio-1.0
 
     build-depends:    tasty                         >= 0.10 && < 1.5,
                       tasty-hunit                   >= 0.10 && < 0.11,
                       -- Import shared with the library don't need bounds
                       base,
+                      directory,
                       lens,
                       swarm,
-                      text
-
+                      text,
+                      witch
     hs-source-dirs:   test
     default-language: Haskell2010
     ghc-options:      -threaded

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -138,6 +138,23 @@ executable swarm
 
 test-suite swarm-unit
     import:           stan-config, common
+    main-is:          Unit.hs
+    type:             exitcode-stdio-1.0
+
+    build-depends:    tasty                         >= 0.10 && < 1.5,
+                      tasty-hunit                   >= 0.10 && < 0.11,
+                      -- Import shared with the library don't need bounds
+                      base,
+                      filepath,
+                      lens,
+                      swarm,
+                      text,
+    hs-source-dirs:   test
+    default-language: Haskell2010
+    ghc-options:      -threaded
+
+test-suite swarm-integration
+    import:           stan-config, common
     main-is:          Integration.hs
     type:             exitcode-stdio-1.0
 
@@ -146,6 +163,7 @@ test-suite swarm-unit
                       -- Import shared with the library don't need bounds
                       base,
                       directory,
+                      filepath,
                       lens,
                       swarm,
                       text,

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -20,6 +20,7 @@ copyright:          Brent Yorgey 2021
 category:           Game
 tested-with:        GHC ==8.10.4 || ==9.0.1
 extra-source-files: CHANGELOG.md
+                    example/*.sw
 data-dir:           data/
 data-files:         *.yaml
 

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -164,7 +164,7 @@ test-suite swarm-integration
 
     build-depends:    tasty                         >= 0.10 && < 1.5,
                       tasty-hunit                   >= 0.10 && < 0.11,
-                      -- Import shared with the library don't need bounds
+                      -- Imports shared with the library don't need bounds
                       base,
                       directory,
                       filepath,

--- a/test/Integration.hs
+++ b/test/Integration.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Swarm unit tests
+module Main where
+
+import Data.Either
+import Control.Monad
+import Data.Text (Text)
+import qualified Data.Text as T
+import Test.Tasty
+import Test.Tasty.HUnit
+import Witch
+
+import Swarm.Language.Pretty
+import Swarm.Language.Syntax hiding (mkOp)
+import Swarm.Language.Pipeline (processTerm)
+import System.Directory (doesFileExist, listDirectory)
+
+main :: IO ()
+main = defaultMain (withResource acquire exampleTests)
+
+exampleTests :: IO [(FilePath, String)] -> TestTree
+exampleTests = testGroup "Examples test" (mapM exampleTest)
+
+exampleTest (path, fileContents) =
+  testCase ("processTerm for contents of " ++ show path)
+    $ assertBool "should return Right value" (isRight . processTerm $ into @Text fileContents)
+
+acquire :: IO [(FilePath, String)]
+acquire = do
+  paths <- listDirectory "example"
+  filePaths <- filterM doesFileExist paths
+  mapM (\path -> (path, readFile path)) filePaths

--- a/test/Integration.hs
+++ b/test/Integration.hs
@@ -5,7 +5,6 @@
 module Main where
 
 import Control.Monad
-import Data.Either
 import Data.Functor
 import Data.Text (Text)
 import System.Directory (doesFileExist, listDirectory)
@@ -26,8 +25,10 @@ exampleTests inputs = testGroup "Test example" (map exampleTest inputs)
 
 exampleTest :: (FilePath, String) -> TestTree
 exampleTest (path, fileContent) = do
-  testCase ("processTerm for contents of " ++ show path) $
-    assertBool "should return Right value" (isRight . processTerm $ into @Text fileContent)
+  testCaseSteps ("processTerm for contents of " ++ show path) $ \_ -> do
+    either (assertFailure . into @String) (const . return $ ()) value
+    where
+      value = processTerm $ into @Text fileContent
 
 acquire :: IO [(FilePath, String)]
 acquire = do

--- a/test/Integration.hs
+++ b/test/Integration.hs
@@ -5,9 +5,9 @@
 module Main where
 
 import Control.Monad
-import Data.Text (Text)
-import Data.Functor
 import Data.Either
+import Data.Functor
+import Data.Text (Text)
 import Swarm.Language.Pipeline (processTerm)
 import System.Directory (doesFileExist, listDirectory)
 import System.FilePath.Posix
@@ -33,5 +33,5 @@ acquire = do
   paths <- listDirectory exampleDirectory <&> map (exampleDirectory </>)
   filePaths <- filterM doesFileExist paths
   mapM (\path -> (,) path <$> readFile path) filePaths
-  where
-    exampleDirectory = "example"
+ where
+  exampleDirectory = "example"

--- a/test/Integration.hs
+++ b/test/Integration.hs
@@ -31,7 +31,8 @@ exampleTest (path, fileContent) = do
 acquire :: IO [(FilePath, String)]
 acquire = do
   paths <- listDirectory exampleDirectory <&> map (exampleDirectory </>)
-  filePaths <- filterM doesFileExist paths
+  filePaths <- filterM (\path -> doesFileExist path <&> (&&) (swExtension path)) paths
   mapM (\path -> (,) path <$> readFile path) filePaths
  where
   exampleDirectory = "example"
+  swExtension path = takeExtension path == ".sw"

--- a/test/Integration.hs
+++ b/test/Integration.hs
@@ -27,8 +27,8 @@ exampleTest :: (FilePath, String) -> TestTree
 exampleTest (path, fileContent) = do
   testCaseSteps ("processTerm for contents of " ++ show path) $ \_ -> do
     either (assertFailure . into @String) (const . return $ ()) value
-    where
-      value = processTerm $ into @Text fileContent
+ where
+  value = processTerm $ into @Text fileContent
 
 acquire :: IO [(FilePath, String)]
 acquire = do

--- a/test/Integration.hs
+++ b/test/Integration.hs
@@ -1,19 +1,20 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
--- | Swarm unit tests
+-- | Swarm integration tests
 module Main where
 
 import Control.Monad
 import Data.Either
 import Data.Functor
 import Data.Text (Text)
-import Swarm.Language.Pipeline (processTerm)
 import System.Directory (doesFileExist, listDirectory)
 import System.FilePath.Posix
 import Test.Tasty
 import Test.Tasty.HUnit
 import Witch
+
+import Swarm.Language.Pipeline (processTerm)
 
 main :: IO ()
 main = do

--- a/test/Integration.hs
+++ b/test/Integration.hs
@@ -4,31 +4,34 @@
 -- | Swarm unit tests
 module Main where
 
-import Data.Either
 import Control.Monad
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Functor
+import Data.Either
+import Swarm.Language.Pipeline (processTerm)
+import System.Directory (doesFileExist, listDirectory)
+import System.FilePath.Posix
 import Test.Tasty
 import Test.Tasty.HUnit
 import Witch
 
-import Swarm.Language.Pretty
-import Swarm.Language.Syntax hiding (mkOp)
-import Swarm.Language.Pipeline (processTerm)
-import System.Directory (doesFileExist, listDirectory)
-
 main :: IO ()
-main = defaultMain (withResource acquire exampleTests)
+main = do
+  paths <- acquire
+  defaultMain . exampleTests $ paths
 
-exampleTests :: IO [(FilePath, String)] -> TestTree
-exampleTests = testGroup "Examples test" (mapM exampleTest)
+exampleTests :: [(FilePath, String)] -> TestTree
+exampleTests inputs = testGroup "Test example" (map exampleTest inputs)
 
-exampleTest (path, fileContents) =
-  testCase ("processTerm for contents of " ++ show path)
-    $ assertBool "should return Right value" (isRight . processTerm $ into @Text fileContents)
+exampleTest :: (FilePath, String) -> TestTree
+exampleTest (path, fileContent) = do
+  testCase ("processTerm for contents of " ++ show path) $
+    assertBool "should return Right value" (isRight . processTerm $ into @Text fileContent)
 
 acquire :: IO [(FilePath, String)]
 acquire = do
-  paths <- listDirectory "example"
+  paths <- listDirectory exampleDirectory <&> map (exampleDirectory </>)
   filePaths <- filterM doesFileExist paths
-  mapM (\path -> (path, readFile path)) filePaths
+  mapM (\path -> (,) path <$> readFile path) filePaths
+  where
+    exampleDirectory = "example"


### PR DESCRIPTION
Closes #180 

Add `Integration.hs` which reads files from `example` folder and runs `processTerm` on the contents. The test passes if creating a term is successful.

Currently only one example i.e. `zigzag.sw` is failing.