### PR TITLE
Store history in XDG data directory

### DIFF
--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -31,6 +31,7 @@ module Swarm.TUI.Controller (
   handleREPLEvent,
   validateREPLForm,
   adjReplHistIndex,
+  TimeDir (..),
 
   -- ** World panel
   handleWorldEvent,
@@ -151,15 +152,12 @@ toggleModal s modal = do
 --   the updated REPL history to a @.swarm_history@ file.
 shutdown :: AppState -> EventM Name (Next AppState)
 shutdown s = do
-  let hist = mapMaybe getNewEntry (s ^. uiState . uiReplHistory)
+  let hist = mapMaybe getREPLEntry $ getLatestREPLHistoryItems maxBound history
   liftIO $ (`T.appendFile` T.unlines hist) =<< getSwarmHistoryPath True
-  let s' = s & uiState . uiReplHistory . traverse %~ markOld
+  let s' = s & uiState . uiReplHistory %~ restartREPLHistory
   halt s'
  where
-  markOld (REPLEntry _ d e) = REPLEntry False d e
-  markOld r = r
-  getNewEntry (REPLEntry True _ t) = Just t
-  getNewEntry _ = Nothing
+  history = s ^. uiState . uiReplHistory
 
 ------------------------------------------------------------
 -- Handling Frame events
@@ -320,7 +318,7 @@ updateUI = do
     -- result as a REPL output, with its type, and reset the replStatus.
     REPLWorking pty (Just v) -> do
       let out = T.intercalate " " [into (prettyValue v), ":", prettyText (stripCmd pty)]
-      uiState . uiReplHistory %= (REPLOutput out :)
+      uiState . uiReplHistory %= addREPLItem (REPLOutput out)
       gameState . replStatus .= REPLDone
       pure True
 
@@ -403,8 +401,7 @@ handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
           s
             & uiState . uiReplForm %~ updateFormState ""
             & uiState . uiReplType .~ Nothing
-            & uiState . uiReplHistory %~ prependReplEntry
-            & uiState . uiReplHistIdx .~ (-1)
+            & uiState . uiReplHistory %~ addREPLItem (REPLEntry entry)
             & uiState . uiError .~ Nothing
             & gameState . replStatus .~ REPLWorking ty Nothing
             & gameState . robotMap . ix "base" . machine .~ initMachine t topValCtx topStore
@@ -422,13 +419,10 @@ handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
   topStore =
     fromMaybe emptyStore $
       s ^? gameState . robotMap . at "base" . _Just . robotContext . defStore
-  prependReplEntry replHistory
-    | firstReplEntry replHistory == Just entry = REPLEntry True True entry : replHistory
-    | otherwise = REPLEntry True False entry : replHistory
 handleREPLEvent s (VtyEvent (V.EvKey V.KUp [])) =
-  continue $ s & adjReplHistIndex (+)
+  continue $ s & adjReplHistIndex Older
 handleREPLEvent s (VtyEvent (V.EvKey V.KDown [])) =
-  continue $ s & adjReplHistIndex (-)
+  continue $ s & adjReplHistIndex Newer
 handleREPLEvent s ev = do
   f' <- handleFormEvent ev (s ^. uiState . uiReplForm)
   continue $ validateREPLForm (s & uiState . uiReplForm .~ f')
@@ -450,21 +444,26 @@ validateREPLForm s =
   validate = setFieldValid (isRight result) REPLInput
 
 -- | Update our current position in the REPL history.
-adjReplHistIndex :: (Int -> Int -> Int) -> AppState -> AppState
-adjReplHistIndex (+/-) s =
-  s & uiState . uiReplHistIdx .~ newIndex
-    & (if curIndex == -1 then saveLastEntry else id)
-    & (if newIndex /= curIndex then uiState . uiReplForm %~ updateFormState newEntry else id)
+adjReplHistIndex :: TimeDir -> AppState -> AppState
+adjReplHistIndex d s =
+  ns
+    & (if replIndexIsAtInput (s ^. repl) then saveLastEntry else id)
+    & (if oldEntry /= newEntry then showNewEntry else id)
     & validateREPLForm
  where
+  -- new AppState after moving the repl index
+  ns = s & repl %~ moveReplHistIndex d oldEntry
+
+  repl :: Lens' AppState REPLHistory
+  repl = uiState . uiReplHistory
+
+  replLast = s ^. uiState . uiReplLast
   saveLastEntry = uiState . uiReplLast .~ formState (s ^. uiState . uiReplForm)
-  entries = [e | REPLEntry _ False e <- s ^. uiState . uiReplHistory]
-  curIndex = s ^. uiState . uiReplHistIdx
-  histLen = length entries
-  newIndex = min (histLen - 1) (max (-1) (curIndex +/- 1))
-  newEntry
-    | newIndex == -1 = s ^. uiState . uiReplLast
-    | otherwise = entries !! newIndex
+  showNewEntry = uiState . uiReplForm %~ updateFormState newEntry
+  -- get REPL data
+  getCurrEntry = fromMaybe replLast . getCurrentItemText . view repl
+  oldEntry = getCurrEntry s
+  newEntry = getCurrEntry ns
 
 ------------------------------------------------------------
 -- World events

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -47,6 +47,7 @@ import qualified Data.List as L
 import Data.List.Split (chunksOf)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
+import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Linear
@@ -556,13 +557,16 @@ drawRobotLog s =
 drawREPL :: AppState -> Widget Name
 drawREPL s =
   vBox $
-    map fmt (reverse (take (replHeight - 1) . filter newEntry $ (s ^. uiState . uiReplHistory)))
-      ++ case isActive <$> (s ^. gameState . robotMap . at "base") of
+    map fmt (getLatestREPLHistoryItems (replHeight - inputLines) history)
+      ++ case isActive <$> base of
         Just False -> [renderForm (s ^. uiState . uiReplForm)]
         _ -> [padRight Max $ txt "..."]
+      ++ [padRight Max $ txt histIdx | debugging]
  where
-  newEntry (REPLEntry False _ _) = False
-  newEntry _ = True
-
-  fmt (REPLEntry _ _ e) = txt replPrompt <+> txt e
+  debugging = False -- Turn ON to get extra line with history index
+  inputLines = 1 + fromEnum debugging
+  history = s ^. uiState . uiReplHistory
+  base = s ^. gameState . robotMap . at "base"
+  histIdx = fromString $ show (history ^. replIndex)
+  fmt (REPLEntry e) = txt replPrompt <+> txt e
   fmt (REPLOutput t) = txt t

--- a/src/Swarm/Util.hs
+++ b/src/Swarm/Util.hs
@@ -24,8 +24,13 @@ module Swarm.Util (
   (?),
   maxOn,
   maximum0,
-  readFileMay,
   cycleEnum,
+
+  -- * Directory utilities
+  readFileMay,
+  readFileMayT,
+  getSwarmDataPath,
+  getSwarmHistoryPath,
 
   -- * English language utilities
   quote,
@@ -57,12 +62,13 @@ import Control.Algebra (Has)
 import Control.Effect.State (State, modify, state)
 import Control.Effect.Throw (Throw, throwError)
 import Control.Lens (ASetter', LensLike, LensLike', Over, (<>~))
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Data.Either.Validation
 import Data.Int (Int64)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import Data.Tuple (swap)
 import Data.Yaml
 import Language.Haskell.TH
@@ -70,7 +76,13 @@ import Language.Haskell.TH.Syntax (lift)
 import Linear (V2)
 import qualified NLP.Minimorph.English as MM
 import NLP.Minimorph.Util ((<+>))
-import System.Directory (doesFileExist)
+import System.Directory (
+  XdgDirectory (XdgData),
+  createDirectoryIfMissing,
+  getXdgDirectory,
+ )
+import System.FilePath
+import System.IO.Error (catchIOError)
 
 infixr 1 ?
 infix 4 %%=, <+=, <%=, <<.=, <>=
@@ -95,19 +107,6 @@ maximum0 :: (Num a, Ord a) => [a] -> a
 maximum0 [] = 0
 maximum0 xs = maximum xs
 
--- | Safely attempt to read a file, returning @Nothing@ if the file
---   does not exist.  \"Safely\" should be read in scare quotes here,
---   since /e.g./ we do nothing to guard against the possibility of a
---   race condition where the file is deleted after the existence
---   check but before trying to read it.  But it's not like we're
---   worried about security or anything here.
-readFileMay :: FilePath -> IO (Maybe String)
-readFileMay file = do
-  b <- doesFileExist file
-  case b of
-    False -> return Nothing
-    True -> Just <$> readFile file
-
 -- | Take the successor of an 'Enum' type, wrapping around when it
 --   reaches the end.
 cycleEnum :: (Eq e, Enum e, Bounded e) => e -> e
@@ -115,7 +114,37 @@ cycleEnum e
   | e == maxBound = minBound
   | otherwise = succ e
 
---------------------------------------------------
+------------------------------------------------------------
+-- Directory stuff
+
+-- | Safely attempt to read a file.
+readFileMay :: FilePath -> IO (Maybe String)
+readFileMay = catchIO . readFile
+
+-- | Safely attempt to (efficiently) read a file.
+readFileMayT :: FilePath -> IO (Maybe Text)
+readFileMayT = catchIO . T.readFile
+
+-- | Turns any IO error into Nothing.
+catchIO :: IO a -> IO (Maybe a)
+catchIO act = (Just <$> act) `catchIOError` (\_ -> return Nothing)
+
+-- | Get path to swarm data, optionally creating necessary
+--   directories.
+getSwarmDataPath :: Bool -> IO FilePath
+getSwarmDataPath createDirs = do
+  swarmData <- getXdgDirectory XdgData "swarm"
+  when createDirs (createDirectoryIfMissing True swarmData)
+  pure swarmData
+
+-- | Get path to swarm history, optionally creating necessary
+--   directories. This could fail if user has bad permissions
+--   on his own $HOME or $XDG_DATA_HOME which is unlikely.
+getSwarmHistoryPath :: Bool -> IO FilePath
+getSwarmHistoryPath createDirs =
+  (</> "history") <$> getSwarmDataPath createDirs
+
+------------------------------------------------------------
 -- Some language-y stuff
 
 -- | Prepend a noun with the proper indefinite article (\"a\" or \"an\").

--- a/swarm.cabal
+++ b/swarm.cabal
@@ -96,6 +96,7 @@ library
                       containers                    >= 0.6.2 && < 0.7,
                       directory                     >= 1.3 && < 1.4,
                       either                        >= 5.0 && < 5.1,
+                      filepath                      >= 1.4 && < 1.5,
                       fused-effects                 >= 1.1.1.1 && < 1.2,
                       fused-effects-lens            >= 1.2.0.1 && < 1.3,
                       hashable                      >= 1.3.4 && < 1.4,

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -8,6 +8,7 @@ module Main where
 import Control.Lens ((&), (.~))
 import Control.Monad.Except
 import Control.Monad.State
+import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Linear
@@ -26,6 +27,7 @@ import Swarm.Language.Context
 import Swarm.Language.Pipeline (ProcessedTerm (..), processTerm)
 import Swarm.Language.Pretty
 import Swarm.Language.Syntax hiding (mkOp)
+import Swarm.TUI.Model
 
 main :: IO ()
 main = do
@@ -35,7 +37,7 @@ main = do
     Right g -> defaultMain (tests g)
 
 tests :: GameState -> TestTree
-tests g = testGroup "Tests" [parser, prettyConst, eval g]
+tests g = testGroup "Tests" [parser, prettyConst, eval g, testModel]
 
 parser :: TestTree
 parser =
@@ -423,3 +425,81 @@ eval g =
   runCESK !steps cesk = case finalValue cesk of
     Just (v, _) -> return (Right (v, steps))
     Nothing -> stepCESK cesk >>= runCESK (steps + 1)
+
+testModel :: TestTree
+testModel =
+  testGroup
+    "TUI Model"
+    [ testCase
+        "latest repl lines at start"
+        ( assertEqual
+            "get 5 history [0] --> []"
+            []
+            (getLatestREPLHistoryItems 5 history0)
+        )
+    , testCase
+        "latest repl lines after one input"
+        ( assertEqual
+            "get 5 history [0|()] --> [()]"
+            [REPLEntry "()"]
+            (getLatestREPLHistoryItems 5 (addREPLItem (REPLEntry "()") history0))
+        )
+    , testCase
+        "latest repl lines after one input and output"
+        ( assertEqual
+            "get 5 history [0|1,1:int] --> [1,1:int]"
+            [REPLEntry "1", REPLOutput "1:int"]
+            (getLatestREPLHistoryItems 5 (addInOutInt 1 history0))
+        )
+    , testCase
+        "latest repl lines after nine inputs and outputs"
+        ( assertEqual
+            "get 6 history [0|1,1:int .. 9,9:int] --> [7,7:int..9,9:int]"
+            (concat [[REPLEntry (toT x), REPLOutput (toT x <> ":int")] | x <- [7 .. 9]])
+            (getLatestREPLHistoryItems 6 (foldl (flip addInOutInt) history0 [1 .. 9]))
+        )
+    , testCase
+        "latest repl after restart"
+        ( assertEqual
+            "get 5 history (restart [0|()]) --> []"
+            []
+            (getLatestREPLHistoryItems 5 (restartREPLHistory $ addREPLItem (REPLEntry "()") history0))
+        )
+    , testCase
+        "current item at start"
+        (assertEqual "getText [0] --> Nothing" (getCurrentItemText history0) Nothing)
+    , testCase
+        "current item after move to older"
+        ( assertEqual
+            "getText ([0]<=='') --> Just 0"
+            (Just "0")
+            (getCurrentItemText $ moveReplHistIndex Older "" history0)
+        )
+    , testCase
+        "current item after move to newer"
+        ( assertEqual
+            "getText ([0]==>'') --> Nothing"
+            Nothing
+            (getCurrentItemText $ moveReplHistIndex Newer "" history0)
+        )
+    , testCase
+        "current item after move past output"
+        ( assertEqual
+            "getText ([0,1,1:int]<=='') --> Just 1"
+            (Just "1")
+            (getCurrentItemText $ moveReplHistIndex Older "" (addInOutInt 1 history0))
+        )
+    , testCase
+        "current item after move past same"
+        ( assertEqual
+            "getText ([0,1,1:int]<=='1') --> Just 0"
+            (Just "0")
+            (getCurrentItemText $ moveReplHistIndex Older "1" (addInOutInt 1 history0))
+        )
+    ]
+ where
+  history0 = newREPLHistory [REPLEntry "0"]
+  toT :: Int -> Text
+  toT = fromString . show
+  addInOutInt :: Int -> REPLHistory -> REPLHistory
+  addInOutInt i = addREPLItem (REPLOutput $ toT i <> ":int") . addREPLItem (REPLEntry $ toT i)


### PR DESCRIPTION
- fixes #136 
- changes the history file format to simple text line per `REPLEntry`
- refactors out a `REPLHistory` type and its pure functions
  - adds tests for REPL logic (move to different previous entry,...)