### PR TITLE
Add `has` and `count` commands

### DIFF
--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -265,6 +265,7 @@
   description:
   - An 8-bit counter.
   properties: [portable]
+  capabilities: [count]
 
 - name: Linux
   display:

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -263,7 +263,13 @@
     attr: device
     char: 'C'
   description:
-  - An 8-bit counter.
+  - "Increment and reset, what more could you want?"
+  - |
+    A counter enables the command 'count : string -> cmd int',
+    which counts how many occurrences of an entity are currently
+    in the inventory.  Note also the 'has' command, which returns
+    a bool instead of an int and does not require any special
+    device.
   properties: [portable]
   capabilities: [count]
 

--- a/data/entities.yaml
+++ b/data/entities.yaml
@@ -267,9 +267,9 @@
   - |
     A counter enables the command 'count : string -> cmd int',
     which counts how many occurrences of an entity are currently
-    in the inventory.  Note also the 'has' command, which returns
-    a bool instead of an int and does not require any special
-    device.
+    in the inventory.  This is an upgraded version of the 'has'
+    command, which returns a bool instead of an int and does
+    not require any special device.
   properties: [portable]
   capabilities: [count]
 

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -57,6 +57,8 @@ data Capability
     CInstall
   | -- | Execute the 'Make' command
     CMake
+  | -- | Execute the 'Count' command
+    CCount
   | -- | Execute the 'Build' command
     CBuild
   | -- | Execute the 'Salvage' command
@@ -241,7 +243,7 @@ constCaps =
     Install -> [CInstall]
     Make -> [CMake]
     Has -> []
-    Count -> []
+    Count -> [CCount]
     If -> [CCond]
     Create -> [CCreate]
     Blocked -> [CSensefront]

--- a/src/Swarm/Language/Capability.hs
+++ b/src/Swarm/Language/Capability.hs
@@ -240,6 +240,8 @@ constCaps =
     Give -> [CGive]
     Install -> [CInstall]
     Make -> [CMake]
+    Has -> []
+    Count -> []
     If -> [CCond]
     Create -> [CCreate]
     Blocked -> [CSensefront]

--- a/src/Swarm/Language/Syntax.hs
+++ b/src/Swarm/Language/Syntax.hs
@@ -218,6 +218,10 @@ data Const
     Install
   | -- | Make an item.
     Make
+  | -- | Sense whether we have a certain item.
+    Has
+  | -- | Sense how many of a certain item we have.
+    Count
   | -- | Drill through an entity.
     Drill
   | -- | Construct a new robot.
@@ -400,6 +404,8 @@ constInfo c = case c of
   Give -> commandLow 2
   Install -> commandLow 2
   Make -> commandLow 1
+  Has -> commandLow 1
+  Count -> commandLow 1
   Reprogram -> commandLow 2
   Drill -> commandLow 1
   Build -> commandLow 2

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -431,6 +431,8 @@ inferConst c = toU $ case c of
   Give -> [tyQ| string -> string -> cmd () |]
   Install -> [tyQ| string -> string -> cmd () |]
   Make -> [tyQ| string -> cmd () |]
+  Has -> [tyQ| string -> cmd bool |]
+  Count -> [tyQ| string -> cmd int |]
   Reprogram -> [tyQ| string -> {cmd a} -> cmd () |]
   Build -> [tyQ| string -> {cmd a} -> cmd string |]
   Drill -> [tyQ| dir -> cmd () |]

--- a/src/Swarm/TUI/View.hs
+++ b/src/Swarm/TUI/View.hs
@@ -220,6 +220,7 @@ helpWidget = (helpKeys <=> fill ' ') <+> (helpCommands <=> fill ' ')
     , ("turn <dir>", "Change the current direction")
     , ("grab", "Grab whatver is available")
     , ("give <robot> <item>", "Give an item to another robot")
+    , ("has <item>", "Check for an item in the inventory")
     ]
 
 -- | Draw the error dialog window, if it should be displayed right now.


### PR DESCRIPTION
Closes #88.

Currently, these commands require no capability and no specific device (you already have an inventory, so why wouldn't you be able to look in it to see what you have?).  However, that makes it impossible to discover these commands without reading the source or tutorial.  Maybe we should make an "inventory" device?  I'm not sure.  Suggestions welcome.  Or maybe once we implement #84 it won't matter since players can discover commands that way.