### PR TITLE
Add location to type matching errors

### DIFF
--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -213,13 +213,17 @@ parseConst = asum $ map alternative consts
   consts = filter isUserFunc allConst
   alternative c = c <$ reserved (syntax $ constInfo c)
 
+-- | Add 'Location' to a parser
+parseLocG :: Parser a -> Parser (Location, a)
+parseLocG pa = do
+  start <- getOffset
+  a <- pa
+  end <- getOffset
+  pure (Location start end, a)
+
 -- | Add 'Location' to a 'Term' parser
 parseLoc :: Parser Term -> Parser Syntax
-parseLoc pterm = do
-  start <- getOffset
-  term <- pterm
-  end <- getOffset
-  pure $ Syntax (Location start end) term
+parseLoc pterm = uncurry Syntax <$> parseLocG pterm
 
 parseTermAtom :: Parser Syntax
 parseTermAtom =
@@ -279,7 +283,7 @@ mkBindChain stmts = case last stmts of
  where
   mkBind (BareTerm t1) t2 = loc t1 t2 $ SBind Nothing t1 t2
   mkBind (Binder x t1) t2 = loc t1 t2 $ SBind (Just x) t1 t2
-  loc a b = Syntax $ sLoc a <> sLoc b 
+  loc a b = Syntax $ sLoc a <> sLoc b
 
 data Stmt
   = BareTerm Syntax
@@ -326,17 +330,11 @@ parseExpr = fixDefMissingSemis <$> makeExprParser parseTermAtom table
       , Map.singleton 2 [InfixR (exprLoc2 $ SPair <$ symbol ",")]
       ]
 
--- | Utility to add empty location for ExprParser
-exprLoc2 :: Parser (Syntax -> Syntax -> Term) -> Parser (Syntax -> Syntax -> Syntax)
-exprLoc2 p = do
-  f <- p
-  pure $ \s1 s2 -> Syntax (sLoc s1 <> sLoc s2) $ f s1 s2
-
--- | Utility to add empty location for ExprParser
-exprLoc1 :: Parser (Syntax -> Term) -> Parser (Syntax -> Syntax)
-exprLoc1 p = do
-  f <- p
-  pure $ \s -> s {sTerm = f s}
+  -- add location for ExprParser by combining all
+  exprLoc2 :: Parser (Syntax -> Syntax -> Term) -> Parser (Syntax -> Syntax -> Syntax)
+  exprLoc2 p = do
+    (l, f) <- parseLocG p
+    pure $ \s1 s2 -> Syntax (l <> sLoc s1 <> sLoc s2) $ f s1 s2
 
 -- | Precedences and parsers of binary operators.
 --
@@ -374,6 +372,12 @@ unOps = Map.unionsWith (++) $ mapMaybe unOpToTuple allConst
       Map.singleton
         (fixity ci)
         [assI (exprLoc1 $ SApp (noLoc $ TConst c) <$ operatorString (syntax ci))]
+
+  -- combine location for ExprParser
+  exprLoc1 :: Parser (Syntax -> Term) -> Parser (Syntax -> Syntax)
+  exprLoc1 p = do
+    (l, f) <- parseLocG p
+    pure $ \s -> Syntax (l <> sLoc s) $ f s
 
 operatorString :: Text -> Parser Text
 operatorString n = (lexeme . try) (string n <* notFollowedBy operatorSymbol)

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -277,8 +277,9 @@ mkBindChain stmts = case last stmts of
   Binder _ _ -> fail "Last command in a chain must not have a binder"
   BareTerm t -> return $ foldr mkBind t (init stmts)
  where
-  mkBind (BareTerm t1) t2 = noLoc $ SBind Nothing t1 t2
-  mkBind (Binder x t1) t2 = noLoc $ SBind (Just x) t1 t2
+  mkBind (BareTerm t1) t2 = loc t1 t2 $ SBind Nothing t1 t2
+  mkBind (Binder x t1) t2 = loc t1 t2 $ SBind (Just x) t1 t2
+  loc a b = Syntax $ sLoc a <> sLoc b 
 
 data Stmt
   = BareTerm Syntax

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -329,13 +329,13 @@ parseExpr = fixDefMissingSemis <$> makeExprParser parseTermAtom table
 exprLoc2 :: Parser (Syntax -> Syntax -> Term) -> Parser (Syntax -> Syntax -> Syntax)
 exprLoc2 p = do
   f <- p
-  pure $ \s1 s2 -> noLoc $ f s1 s2
+  pure $ \s1 s2 -> Syntax (sLoc s1 <> sLoc s2) $ f s1 s2
 
 -- | Utility to add empty location for ExprParser
 exprLoc1 :: Parser (Syntax -> Term) -> Parser (Syntax -> Syntax)
 exprLoc1 p = do
   f <- p
-  pure $ \s -> noLoc $ f s
+  pure $ \s -> s {sTerm = f s}
 
 -- | Precedences and parsers of binary operators.
 --

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -280,10 +280,10 @@ inferModule s@(Syntax _ t) = (`catchError` addLocToTypeErr s) $ case t of
   -- correct context when checking the right-hand side in particular.
   SBind mx c1 c2 -> do
     -- First, infer the left side.
-    (a,ctx1) <- (`catchError` addLocToTypeErr c1) $ do
-      Module cmda ctx1 <- inferModule c1 
+    (a, ctx1) <- (`catchError` addLocToTypeErr c1) $ do
+      Module cmda ctx1 <- inferModule c1
       a <- decomposeCmdTy cmda
-      pure (a,ctx1)
+      pure (a, ctx1)
 
     -- Now infer the right side under an extended context: things in
     -- scope on the right-hand side include both any definitions

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -280,10 +280,8 @@ inferModule s@(Syntax _ t) = (`catchError` addLocToTypeErr s) $ case t of
   -- correct context when checking the right-hand side in particular.
   SBind mx c1 c2 -> do
     -- First, infer the left side.
-    (a, ctx1) <- (`catchError` addLocToTypeErr c1) $ do
-      Module cmda ctx1 <- inferModule c1
-      a <- decomposeCmdTy cmda
-      pure (a, ctx1)
+    Module cmda ctx1 <- inferModule c1
+    a <- decomposeCmdTy cmda
 
     -- Now infer the right side under an extended context: things in
     -- scope on the right-hand side include both any definitions
@@ -292,7 +290,7 @@ inferModule s@(Syntax _ t) = (`catchError` addLocToTypeErr s) $ case t of
     -- c1 could define something with the same name as x, in which
     -- case the bound x should shadow the defined one; hence, we apply
     -- that binding /after/ (i.e. /within/) the application of @ctx1@.
-    (`catchError` addLocToTypeErr c2) . withBindings ctx1 $
+    withBindings ctx1 $
       maybe id (`withBinding` Forall [] a) mx $ do
         Module cmdb ctx2 <- inferModule c2
 

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -280,8 +280,10 @@ inferModule s@(Syntax _ t) = (`catchError` addLocToTypeErr s) $ case t of
   -- correct context when checking the right-hand side in particular.
   SBind mx c1 c2 -> do
     -- First, infer the left side.
-    Module cmda ctx1 <- inferModule c1
-    a <- decomposeCmdTy cmda
+    (a,ctx1) <- (`catchError` addLocToTypeErr c1) $ do
+      Module cmda ctx1 <- inferModule c1 
+      a <- decomposeCmdTy cmda
+      pure (a,ctx1)
 
     -- Now infer the right side under an extended context: things in
     -- scope on the right-hand side include both any definitions
@@ -290,7 +292,7 @@ inferModule s@(Syntax _ t) = (`catchError` addLocToTypeErr s) $ case t of
     -- c1 could define something with the same name as x, in which
     -- case the bound x should shadow the defined one; hence, we apply
     -- that binding /after/ (i.e. /within/) the application of @ctx1@.
-    withBindings ctx1 $
+    (`catchError` addLocToTypeErr c2) . withBindings ctx1 $
       maybe id (`withBinding` Forall [] a) mx $ do
         Module cmdb ctx2 <- inferModule c2
 

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -255,7 +255,7 @@ inferTop ctx = runInfer ctx . inferModule
 -- | Infer the signature of a top-level expression which might
 --   contain definitions.
 inferModule :: Syntax -> Infer UModule
-inferModule s@(Syntax _ t) = case t of
+inferModule s@(Syntax _ t) = (`catchError` addLocToTypeErr s) $ case t of
   -- For definitions with no type signature, make up a fresh type
   -- variable for the body, infer the body under an extended context,
   -- and unify the two.  Then generalize the type and return an
@@ -398,7 +398,7 @@ infer (Syntax _ (SBind mx c1 c2)) = do
 
 addLocToTypeErr :: Syntax -> TypeErr -> Infer a
 addLocToTypeErr s te = case te of
-  Mismatch _ a b -> throwError $ Mismatch (sLoc s) a b
+  Mismatch NoLoc a b -> throwError $ Mismatch (sLoc s) a b
   _ -> throwError te
 
 -- | Decompose a type that is supposed to be a command type.


### PR DESCRIPTION
- closes #268 
- computes the location for `SBind` and operators