### PR TITLE
allow ' in variable names

### DIFF
--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -124,7 +124,7 @@ reserved w = (lexeme . try) $ string' w *> notFollowedBy (alphaNumChar <|> char 
 identifier :: Parser Text
 identifier = (lexeme . try) (p >>= check) <?> "variable name"
  where
-  p = (:) <$> (letterChar <|> char '_') <*> many (alphaNumChar <|> char '_')
+  p = (:) <$> (letterChar <|> char '_') <*> many (alphaNumChar <|> char '_' <|> char '\'')
   check s
     | toLower t `elem` reservedWords =
       fail $ "reserved word '" ++ s ++ "' cannot be used as variable name"

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -86,6 +86,23 @@ parser =
     , testCase
         "parsing operators #??? - parse valid operator ($)"
         (valid "fst $ snd $ (1,2,3)")
+    , testCase
+        "Allow ' in variable names #269 - parse variable name containing '"
+        (valid "def a'_' = 0 end")
+    , testCase
+        "Allow ' in variable names #269 - do not parse variable starting with '"
+        ( process
+            "def 'a = 0 end"
+            ( T.unlines
+                [ "1:5:"
+                , "  |"
+                , "1 | def 'a = 0 end"
+                , "  |     ^"
+                , "unexpected '''"
+                , "expecting variable name"
+                ]
+            )
+        )
     ]
  where
   valid = flip process ""


### PR DESCRIPTION
Closes #269 

- The parser now accepts  `'` in a variable name as long as it does not start with `'` (to rule out potentially problematic variable names like `'a'`).
- Unit tests for this are added.