### PR TITLE
Add challenge world seed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,13 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=Haskell-CI - Linux - ghc-9.0.1
+      - check-success=Haskell-CI - Linux - ghc-8.10.4
+
 pull_request_rules:
 - actions:
-    merge:
-      strict: smart
+    queue:
+      name: default
       method: squash
       commit_message: title+body
   name: Automatically merge pull requests

--- a/data/challenges/w0.yaml
+++ b/data/challenges/w0.yaml
@@ -1,0 +1,42 @@
+name: Moving, part 1
+entities:
+  - name: goal
+    display:
+      attr: device
+      char: 'X'
+    description:
+    - |
+      Robots can use the 'move' command to move forward one unit
+      in the direction they are currently facing.  To complete
+      this challenge, move your robot two spaces to the right, to
+      the coordinates (2,0).
+    properties: [portable]
+win: |
+  try {
+    loc <- as "base" {whereami};
+    return (loc == (2,0))
+  } { return false }
+robots:
+  - name: base
+    loc: [0,0]
+    dir: [1,0]
+    devices:
+      - treads
+      - logger
+    inventory:
+      - [1, goal]
+world:
+  seed: 0
+  palette:
+    '.': [grass, null]
+    '┌': [stone, upper left corner]
+    '┐': [stone, upper right corner]
+    '└': [stone, lower left corner]
+    '┘': [stone, lower right corner]
+    '─': [stone, horizontal wall]
+    '│': [stone, vertical wall]
+  upperleft: [-1, 1]
+  map: |
+    ┌───┐
+    │...│
+    └───┘

--- a/src/Swarm/Game/Challenge.hs
+++ b/src/Swarm/Game/Challenge.hs
@@ -32,7 +32,7 @@ module Swarm.Game.Challenge (
   challengeWin,
 ) where
 
-import Control.Arrow ((***), Arrow (first))
+import Control.Arrow (Arrow (first), (***))
 import Control.Lens hiding (from)
 import Data.Array
 import Data.HashMap.Strict (HashMap)
@@ -49,9 +49,9 @@ import Swarm.Game.Entity
 import Swarm.Game.Robot (Robot)
 import Swarm.Game.Terrain
 import Swarm.Game.World
+import Swarm.Game.WorldGen (testWorld2FromArray)
 import Swarm.Language.Pipeline (ProcessedTerm)
 import Swarm.Util.Yaml
-import Swarm.Game.WorldGen (testWorld2FromArray)
 
 -- | A 'Challenge' contains all the information to describe a
 --   challenge.
@@ -154,11 +154,11 @@ mkWorldFun pwd = E $ \em -> do
     Left seed -> return $ \entities ->
       let emPlus = em <> entities
           arr2 = bimap toEnum (fmap (^. entityName)) <$> arr
-      in (lkup emPlus <$>) . first fromEnum <$> testWorld2FromArray arr2 seed
+       in (lkup emPlus <$>) . first fromEnum <$> testWorld2FromArray arr2 seed
     Right def ->
-        let defTerrain = (fromEnum *** (>>= (`lookupEntityName` em))) def
-        in return . const $ worldFunFromArray arr defTerrain
-  where
-      lkup :: EntityMap -> Maybe Text -> Maybe Entity
-      lkup _ Nothing = Nothing
-      lkup em (Just t) = lookupEntityName t em
+      let defTerrain = (fromEnum *** (>>= (`lookupEntityName` em))) def
+       in return . const $ worldFunFromArray arr defTerrain
+ where
+  lkup :: EntityMap -> Maybe Text -> Maybe Entity
+  lkup _ Nothing = Nothing
+  lkup em (Just t) = lookupEntityName t em

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -437,7 +437,7 @@ initGameState gtype = do
             . fmap ((lkup entities <$>) . first fromEnum)
             . findGoodOrigin
             $ testWorld2 seed
-        IChallengeGame c -> W.newWorld (c ^. challengeWorld)
+        IChallengeGame c -> W.newWorld $ (c ^. challengeWorld) entities
 
       theWinCondition = case iGameType of
         IClassicGame _ -> NoWinCondition

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -437,7 +437,7 @@ initGameState gtype = do
             . fmap ((lkup entities <$>) . first fromEnum)
             . findGoodOrigin
             $ testWorld2 seed
-        IChallengeGame c -> W.newWorld $ (c ^. challengeWorld) entities
+        IChallengeGame c -> W.newWorld (c ^. challengeWorld)
 
       theWinCondition = case iGameType of
         IClassicGame _ -> NoWinCondition

--- a/src/Swarm/Game/WorldGen.hs
+++ b/src/Swarm/Game/WorldGen.hs
@@ -24,11 +24,11 @@ import Numeric.Noise.Perlin
 import Numeric.Noise.Ridged
 import Witch
 
-import Swarm.Game.Terrain
-import Swarm.Game.World
 import qualified Data.Array as A
 import Data.Array.IArray
 import qualified Data.Array.Unboxed as U
+import Swarm.Game.Terrain
+import Swarm.Game.World
 
 -- | A simple test world I used for a while during early development.
 testWorld1 :: WorldFun TerrainType Text

--- a/src/Swarm/Game/WorldGen.hs
+++ b/src/Swarm/Game/WorldGen.hs
@@ -24,9 +24,7 @@ import Numeric.Noise.Perlin
 import Numeric.Noise.Ridged
 import Witch
 
-import qualified Data.Array as A
 import Data.Array.IArray
-import qualified Data.Array.Unboxed as U
 import Swarm.Game.Terrain
 import Swarm.Game.World
 

--- a/src/Swarm/Game/WorldGen.hs
+++ b/src/Swarm/Game/WorldGen.hs
@@ -26,6 +26,9 @@ import Witch
 
 import Swarm.Game.Terrain
 import Swarm.Game.World
+import qualified Data.Array as A
+import Data.Array.IArray
+import qualified Data.Array.Unboxed as U
 
 -- | A simple test world I used for a while during early development.
 testWorld1 :: WorldFun TerrainType Text
@@ -102,6 +105,16 @@ testWorld2 baseSeed (Coords ix@(r, c)) =
   clumps seed = perlin (seed + baseSeed) 4 0.08 0.5
 
   cl0 = clumps 0
+
+-- | Create a world function from a finite array of specified cells
+--   plus a seed to randomly generate the rest.
+testWorld2FromArray :: Array (Int64, Int64) (TerrainType, Maybe Text) -> Seed -> WorldFun TerrainType Text
+testWorld2FromArray arr seed co@(Coords (r, c))
+  | inRange bnds (r, c) = arr ! (r, c)
+  | otherwise = tw2 co
+ where
+  tw2 = testWorld2 seed
+  bnds = bounds arr
 
 -- | Offset the world so the base starts on empty spot next to tree and grass.
 findGoodOrigin :: WorldFun t Text -> WorldFun t Text


### PR DESCRIPTION
This is a WIP to fix missing world seed option in challenge mode.

From [#285 comment](https://github.com/byorgey/swarm/pull/285#issuecomment-974187422):
>  - [ ] Ability to specify a world seed instead of a default cell content, so we can have challenges that take place in random worlds a la classic mode

It works, but the code needs some polishing :sweat_smile: 

![Screenshot from 2021-11-25 13-17-50](https://user-images.githubusercontent.com/44544735/143440415-24119675-5ad8-4a74-affa-a80f3518b11f.png)


