### PR TITLE
generalize `scan` to return `() + string`

### DIFF
--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -827,11 +827,13 @@ execConst c vs s k = do
         orient <- use robotOrientation
         let scanLoc = loc ^+^ applyTurn d (orient ? zero)
         me <- entityAt scanLoc
-        case me of
-          Nothing -> return ()
-          Just e -> robotInventory %= insertCount 0 e
+        res <- case me of
+          Nothing -> return $ VInj False VUnit
+          Just e -> do
+            robotInventory %= insertCount 0 e
+            return $ VInj True (VString (e ^. entityName))
 
-        return $ Out VUnit s k
+        return $ Out res s k
       _ -> badConst
     Upload -> case vs of
       [VString otherName] -> do

--- a/src/Swarm/Language/Typecheck.hs
+++ b/src/Swarm/Language/Typecheck.hs
@@ -445,7 +445,7 @@ inferConst c = toU $ case c of
   Create -> [tyQ| string -> cmd () |]
   Whereami -> [tyQ| cmd (int * int) |]
   Blocked -> [tyQ| cmd bool |]
-  Scan -> [tyQ| dir -> cmd () |]
+  Scan -> [tyQ| dir -> cmd (() + string) |]
   Upload -> [tyQ| string -> cmd () |]
   Ishere -> [tyQ| string -> cmd bool |]
   Whoami -> [tyQ| cmd string |]


### PR DESCRIPTION
Players can ignore the return value until they have the capability to
deal with sum types.  `scan` still has the effect of adding
information to one's inventory.

Closes #267.