### PR TITLE
allow only whitespace when reading a term

### DIFF
--- a/src/Swarm/Game/Step.hs
+++ b/src/Swarm/Game/Step.hs
@@ -1158,11 +1158,13 @@ execConst c vs s k = do
 
         f <- msum mf `isJustOrFail` ["File not found:", fileName]
 
-        t <-
+        mt <-
           processTerm (into @Text f) `isRightOr` \err ->
             cmdExn Run ["Error in", fileName, "\n", err]
 
-        return $ initMachine' t empty emptyStore k
+        return $ case mt of
+          Nothing -> idleMachine
+          Just t -> initMachine' t empty emptyStore k
       _ -> badConst
     Not -> case vs of
       [VBool b] -> return $ Out (VBool (not b)) s k

--- a/src/Swarm/Language/LSP.hs
+++ b/src/Swarm/Language/LSP.hs
@@ -69,7 +69,8 @@ validateSwarmCode doc version content = do
   -- debug $ "Validating: " <> from (show doc) <> " ( " <> content <> ")"
   flushDiagnosticsBySource 0 (Just "swarm-lsp")
   let err = case readTerm' content of
-        Right term -> case processParsedTerm' mempty mempty term of
+        Right Nothing -> Nothing
+        Right (Just term) -> case processParsedTerm' mempty mempty term of
           Right _ -> Nothing
           Left e -> Just $ showTypeErrorPos content e
         Left e -> Just $ showErrorPos e

--- a/src/Swarm/Language/Parse.hs
+++ b/src/Swarm/Language/Parse.hs
@@ -430,17 +430,24 @@ runParserTH (file, line, col) p s =
 fully :: Parser a -> Parser a
 fully p = sc *> p <* eof
 
+-- | Run a parser "fully", consuming leading whitespace (including the
+--   possibility that the input is nothing but whitespace) and
+--   ensuring that the parser extends all the way to eof.
+fullyMaybe :: Parser a -> Parser (Maybe a)
+fullyMaybe = fully . optional
+
 -- | Parse some input 'Text' completely as a 'Term', consuming leading
 --   whitespace and ensuring the parsing extends all the way to the
---   end of the input 'Text'.  Returns either the resulting 'Term' or
---   a pretty-printed parse error message.
-readTerm :: Text -> Either Text Syntax
-readTerm = runParser (fully parseTerm)
+--   end of the input 'Text'.  Returns either the resulting 'Term' (or
+--   @Nothing@ if the input was only whitespace) or a pretty-printed
+--   parse error message.
+readTerm :: Text -> Either Text (Maybe Syntax)
+readTerm = runParser (fullyMaybe parseTerm)
 
--- | A lower-level readTerm which returns the megaparsec bundle error
+-- | A lower-level `readTerm` which returns the megaparsec bundle error
 --   for precise error reporting.
-readTerm' :: Text -> Either ParserError Syntax
-readTerm' = parse (runReaderT (fully parseTerm) DisallowAntiquoting) ""
+readTerm' :: Text -> Either ParserError (Maybe Syntax)
+readTerm' = parse (runReaderT (fullyMaybe parseTerm) DisallowAntiquoting) ""
 
 -- | A utility for converting a ParserError into a one line message:
 --   <line-nr>: <error-msg>

--- a/src/Swarm/Language/Pipeline.hs
+++ b/src/Swarm/Language/Pipeline.hs
@@ -1,5 +1,3 @@
------------------------------------------------------------------------------
------------------------------------------------------------------------------
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
@@ -61,8 +59,9 @@ data ProcessedTerm
 --   3. Elaborate it (see "Swarm.Language.Elaborate")
 --   4. Check what capabilities it requires (see "Swarm.Language.Capability")
 --
---   Return either the end result or a pretty-printed error message.
-processTerm :: Text -> Either Text ProcessedTerm
+--   Return either the end result (or @Nothing@ if the input was only
+--   whitespace) or a pretty-printed error message.
+processTerm :: Text -> Either Text (Maybe ProcessedTerm)
 processTerm = processTerm' empty empty
 
 -- | Like 'processTerm', but use a term that has already been parsed.
@@ -70,10 +69,10 @@ processParsedTerm :: Syntax -> Either TypeErr ProcessedTerm
 processParsedTerm = processParsedTerm' empty empty
 
 -- | Like 'processTerm', but use explicit starting contexts.
-processTerm' :: TCtx -> CapCtx -> Text -> Either Text ProcessedTerm
+processTerm' :: TCtx -> CapCtx -> Text -> Either Text (Maybe ProcessedTerm)
 processTerm' ctx capCtx txt = do
-  t <- readTerm txt
-  first (prettyTypeErr txt) $ processParsedTerm' ctx capCtx t
+  mt <- readTerm txt
+  first (prettyTypeErr txt) $ traverse (processParsedTerm' ctx capCtx) mt
 
 prettyTypeErr :: Text -> TypeErr -> Text
 prettyTypeErr code te = teLoc <> prettyText te

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -397,19 +397,20 @@ handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
   if not $ s ^. gameState . replWorking
     then case processTerm' topTypeCtx topCapCtx entry of
       Right mt -> do
-        let s' = s
-              & uiState . uiReplForm %~ updateFormState ""
-              & uiState . uiReplType .~ Nothing
-              & uiState . uiReplHistory %~ addREPLItem (REPLEntry entry)
-              & uiState . uiError .~ Nothing
+        let s' =
+              s
+                & uiState . uiReplForm %~ updateFormState ""
+                & uiState . uiReplType .~ Nothing
+                & uiState . uiReplHistory %~ addREPLItem (REPLEntry entry)
+                & uiState . uiError .~ Nothing
         let s'' = case mt of
-              Nothing -> s'  -- user entered only whitespace
-              Just t@(ProcessedTerm _ (Module ty _) _ _) -> s'
-                & gameState . replStatus .~ REPLWorking ty Nothing
-                & gameState . robotMap . ix "base" . machine .~ initMachine t topValCtx topStore
-                & gameState %~ execState (activateRobot "base")
+              Nothing -> s' -- user entered only whitespace
+              Just t@(ProcessedTerm _ (Module ty _) _ _) ->
+                s'
+                  & gameState . replStatus .~ REPLWorking ty Nothing
+                  & gameState . robotMap . ix "base" . machine .~ initMachine t topValCtx topStore
+                  & gameState %~ execState (activateRobot "base")
         continue s''
-
       Left err ->
         continue $
           s

--- a/src/Swarm/TUI/Controller.hs
+++ b/src/Swarm/TUI/Controller.hs
@@ -396,16 +396,20 @@ handleREPLEvent s (VtyEvent (V.EvKey (V.KChar 'c') [V.MCtrl])) =
 handleREPLEvent s (VtyEvent (V.EvKey V.KEnter [])) =
   if not $ s ^. gameState . replWorking
     then case processTerm' topTypeCtx topCapCtx entry of
-      Right t@(ProcessedTerm _ (Module ty _) _ _) ->
-        continue $
-          s
-            & uiState . uiReplForm %~ updateFormState ""
-            & uiState . uiReplType .~ Nothing
-            & uiState . uiReplHistory %~ addREPLItem (REPLEntry entry)
-            & uiState . uiError .~ Nothing
-            & gameState . replStatus .~ REPLWorking ty Nothing
-            & gameState . robotMap . ix "base" . machine .~ initMachine t topValCtx topStore
-            & gameState %~ execState (activateRobot "base")
+      Right mt -> do
+        let s' = s
+              & uiState . uiReplForm %~ updateFormState ""
+              & uiState . uiReplType .~ Nothing
+              & uiState . uiReplHistory %~ addREPLItem (REPLEntry entry)
+              & uiState . uiError .~ Nothing
+        let s'' = case mt of
+              Nothing -> s'  -- user entered only whitespace
+              Just t@(ProcessedTerm _ (Module ty _) _ _) -> s'
+                & gameState . replStatus .~ REPLWorking ty Nothing
+                & gameState . robotMap . ix "base" . machine .~ initMachine t topValCtx topStore
+                & gameState %~ execState (activateRobot "base")
+        continue s''
+
       Left err ->
         continue $
           s
@@ -439,7 +443,7 @@ validateREPLForm s =
   topCapCtx = s ^. gameState . robotMap . ix "base" . robotContext . defCaps
   result = processTerm' topTypeCtx topCapCtx (s ^. uiState . uiReplForm . to formState)
   theType = case result of
-    Right (ProcessedTerm _ (Module ty _) _ _) -> Just ty
+    Right (Just (ProcessedTerm _ (Module ty _) _ _)) -> Just ty
     _ -> Nothing
   validate = setFieldValid (isRight result) REPLInput
 

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -429,8 +429,13 @@ eval g =
         assertEqual "" val v
         assertBool ("Took more than " ++ show maxSteps ++ " steps!") (steps <= maxSteps)
 
+  processTerm1 :: Text -> Either Text ProcessedTerm
+  processTerm1 txt = processTerm txt >>= maybe wsErr Right
+    where
+      wsErr = Left "expecting a term, but got only whitespace"
+
   evaluate :: Text -> IO (Either Text (Value, Int))
-  evaluate = either (return . Left) evalPT . processTerm
+  evaluate = either (return . Left) evalPT . processTerm1
 
   evalPT :: ProcessedTerm -> IO (Either Text (Value, Int))
   evalPT t = evaluateCESK (initMachine t empty emptyStore)

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -431,8 +431,8 @@ eval g =
 
   processTerm1 :: Text -> Either Text ProcessedTerm
   processTerm1 txt = processTerm txt >>= maybe wsErr Right
-    where
-      wsErr = Left "expecting a term, but got only whitespace"
+   where
+    wsErr = Left "expecting a term, but got only whitespace"
 
   evaluate :: Text -> IO (Either Text (Value, Int))
   evaluate = either (return . Left) evalPT . processTerm1


### PR DESCRIPTION
- The user can now enter only whitespace (including comments) at the
  REPL.
- A new file which is blank / only comments is no longer invalid from
  the perspective of LSP.

Closes #275.