### PR TITLE
Track whether robots have an ID number or not at the type level

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright Brent Yorgey 2021
+Copyright Brent Yorgey 2021-2022
 SPDX-License-Identifier: BSD-3-Clause
 
 All rights reserved.

--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -71,7 +71,7 @@ circlerProgram =
 
 -- | Initializes a robot with program prog at location loc facing north.
 initRobot :: ProcessedTerm -> V2 Int64 -> Robot
-initRobot prog loc = mkRobot (-1) Nothing "" [] north loc defaultRobotDisplay (initMachine prog Context.empty emptyStore) [] [] False
+initRobot prog loc = mkRobot (Const ()) Nothing "" [] north loc defaultRobotDisplay (initMachine prog Context.empty emptyStore) [] [] False
 
 -- | Creates a GameState with numRobot copies of robot on a blank map, aligned
 --   in a row starting at (0,0) and spreading east.

--- a/src/Swarm/Game/Challenge.hs
+++ b/src/Swarm/Game/Challenge.hs
@@ -47,7 +47,7 @@ import Linear.V2
 import Witch (from, into)
 
 import Swarm.Game.Entity
-import Swarm.Game.Robot (Robot)
+import Swarm.Game.Robot (URobot)
 import Swarm.Game.Terrain
 import Swarm.Game.World
 import Swarm.Game.WorldGen (testWorld2FromArray)
@@ -61,7 +61,7 @@ data Challenge = Challenge
   , _challengeSeed :: Maybe Int
   , _challengeEntities :: EntityMap
   , _challengeWorld :: WorldFun Int Entity
-  , _challengeRobots :: [Robot]
+  , _challengeRobots :: [URobot]
   , _challengeWin :: ProcessedTerm
   }
 
@@ -93,7 +93,7 @@ challengeWorld :: Lens' Challenge (WorldFun Int Entity)
 
 -- | The starting robots for the challenge.  Note this should
 --   include the "base".
-challengeRobots :: Lens' Challenge [Robot]
+challengeRobots :: Lens' Challenge [URobot]
 
 -- | The winning condition for the challenge, expressed as a
 --   program of type @cmd bool@.  By default, this program will be


### PR DESCRIPTION
See the discussion at https://github.com/byorgey/swarm/pull/303#discussion_r817471340 . This seems like an unqualified success: no more hacky (-1)'s, and doing the refactoring actually uncovered a bug!  Previously, we were not actually assigning ID's to the robots that were read as part of a challenge.  This means that in a challenge with multiple robots, all but one of them would instantly disappear since they all shared the same ID number.
