### PR TITLE
Add a `--run` flag to run the contents of a program on startup

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,7 +14,8 @@ import Swarm.Language.Pipeline (processTerm)
 import System.Exit
 
 data CLI
-  = Run Int (Maybe FilePath)
+  -- seed, challenge file, run file
+  = Run Int (Maybe FilePath) (Maybe FilePath)
   | Format Input
   | LSP
 
@@ -24,7 +25,7 @@ cliParser =
     ( command "format" (info (format <**> helper) (progDesc "Format a file"))
         <> command "lsp" (info (pure LSP) (progDesc "Start the LSP"))
     )
-    <|> Run <$> seed <*> challenge
+    <|> Run <$> seed <*> challenge <*> run
  where
   format :: Parser CLI
   format =
@@ -34,6 +35,8 @@ cliParser =
   seed = option auto (long "seed" <> short 's' <> value 0 <> metavar "INT" <> help "Seed for world generation")
   challenge :: Parser (Maybe String)
   challenge = optional $ strOption (long "challenge" <> short 'c' <> metavar "FILE" <> help "Name of a challenge to load")
+  run :: Parser (Maybe String)
+  run = optional $ strOption (long "run" <> short 'r' <> metavar "FILE" <> help "Run the commands in a file at startup")
 
 cliInfo :: ParserInfo CLI
 cliInfo =
@@ -70,6 +73,6 @@ main :: IO ()
 main = do
   cli <- execParser cliInfo
   case cli of
-    Run seed challenge -> appMain seed challenge
+    Run seed challenge toRun -> appMain seed challenge toRun
     Format fo -> formatFile fo
     LSP -> lspMain

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,8 +14,8 @@ import Swarm.Language.Pipeline (processTerm)
 import System.Exit
 
 data CLI
-  -- seed, challenge file, run file
-  = Run Int (Maybe FilePath) (Maybe FilePath)
+  = -- seed, challenge file, run file
+    Run Int (Maybe FilePath) (Maybe FilePath)
   | Format Input
   | LSP
 

--- a/bench/Benchmark.hs
+++ b/bench/Benchmark.hs
@@ -79,7 +79,7 @@ initRobot prog loc = mkRobot (F.Const ()) Nothing "" [] north loc defaultRobotDi
 mkGameState :: (V2 Int64 -> URobot) -> Int -> IO GameState
 mkGameState robotMaker numRobots = do
   let robots = [robotMaker (V2 (fromIntegral x) 0) | x <- [0 .. numRobots -1]]
-  Right initState <- runExceptT (initGameState (ClassicGame 0))
+  Right initState <- runExceptT (initGameState (ClassicGame 0) Nothing)
   execStateT
     (mapM addURobot robots)
     ( initState

--- a/src/Swarm/App.hs
+++ b/src/Swarm/App.hs
@@ -38,9 +38,9 @@ app =
 
 -- | The main @IO@ computation which initializes the state, sets up
 --   some communication channels, and runs the UI.
-appMain :: Seed -> Maybe String -> IO ()
-appMain seed challenge = do
-  res <- runExceptT $ initAppState seed challenge
+appMain :: Seed -> Maybe String -> Maybe String -> IO ()
+appMain seed challenge toRun = do
+  res <- runExceptT $ initAppState seed challenge toRun
   case res of
     Left errMsg -> T.putStrLn errMsg
     Right s -> do

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -2,9 +2,12 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Module      :  Swarm.Game.Robot
@@ -69,6 +72,7 @@ module Swarm.Game.Robot (
 ) where
 
 import Control.Lens hiding (contains)
+import Data.Hashable (hashWithSalt)
 import Data.Int (Int64)
 import Data.Maybe (isNothing)
 import Data.Sequence (Seq)
@@ -77,18 +81,19 @@ import Data.Set (Set)
 import Data.Set.Lens (setOf)
 import Data.Text (Text)
 import Linear
+import Witch (into)
 
 import Data.Yaml ((.!=), (.:), (.:?))
 import Swarm.Util.Yaml
 
-import Data.Hashable (hashWithSalt)
 import Swarm.Game.CESK
 import Swarm.Game.Display
 import Swarm.Game.Entity hiding (empty)
 import Swarm.Game.Value as V
 import Swarm.Language.Capability
 import Swarm.Language.Context
-import Swarm.Language.Syntax (east)
+import Swarm.Language.Pipeline.QQ (tmQ)
+import Swarm.Language.Syntax (Term (TString), east)
 import Swarm.Language.Types (TCtx)
 
 -- | A record that stores the information
@@ -382,8 +387,8 @@ mkRobot rid pid name descr loc dir disp m devs inv sys =
   inst = fromList devs
 
 -- | The initial robot representing your "base".
-baseRobot :: [Entity] -> Robot
-baseRobot devs =
+baseRobot :: [Entity] -> Maybe FilePath -> Robot
+baseRobot devs toRun =
   RobotR
     { _robotEntity =
         mkEntity
@@ -401,7 +406,9 @@ baseRobot devs =
     , _robotContext = RobotContext empty empty empty emptyStore
     , _robotID = 0
     , _robotParentID = Nothing
-    , _machine = idleMachine
+    , _machine = case toRun of
+        Nothing -> idleMachine
+        Just (into @Text -> f) -> initMachine [tmQ| run($str:f) |] empty emptyStore
     , _systemRobot = False
     , _selfDestruct = False
     , _tickSteps = 0

--- a/src/Swarm/Game/Robot.hs
+++ b/src/Swarm/Game/Robot.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- |

--- a/src/Swarm/Game/State.hs
+++ b/src/Swarm/Game/State.hs
@@ -411,8 +411,8 @@ instGameType em _rs gt = case gt of
 
 -- | Create an initial game state record for a particular game type,
 --   first loading entities and recipies from disk.
-initGameState :: GameType -> ExceptT Text IO GameState
-initGameState gtype = do
+initGameState :: GameType -> Maybe String -> ExceptT Text IO GameState
+initGameState gtype toRun = do
   liftIO $ putStrLn "Loading entities..."
   entities <- loadEntities >>= (`isRightOr` id)
   liftIO $ putStrLn "Loading recipes..."
@@ -439,7 +439,7 @@ initGameState gtype = do
         ]
       baseDevices = mapMaybe (`lookupEntityName` entities) baseDeviceNames
       baseID = 0
-      theBase = baseRobot baseDevices
+      theBase = baseRobot baseDevices toRun
 
       robotList = case iGameType of
         IClassicGame _ -> [theBase]

--- a/src/Swarm/TUI/Model.hs
+++ b/src/Swarm/TUI/Model.hs
@@ -558,10 +558,10 @@ gameState :: Lens' AppState GameState
 uiState :: Lens' AppState UIState
 
 -- | Initialize the 'AppState'.
-initAppState :: Seed -> Maybe String -> ExceptT Text IO AppState
-initAppState seed challenge = do
+initAppState :: Seed -> Maybe String -> Maybe String -> ExceptT Text IO AppState
+initAppState seed challenge toRun = do
   let gtype = initGameType seed challenge
-  AppState <$> initGameState gtype <*> initUIState
+  AppState <$> initGameState gtype toRun <*> initUIState
 
 initGameType :: Seed -> Maybe String -> GameType
 initGameType seed Nothing = ClassicGame seed

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -35,7 +35,7 @@ import Swarm.TUI.Model
 
 main :: IO ()
 main = do
-  mg <- runExceptT (initGameState (ClassicGame 0))
+  mg <- runExceptT (initGameState (ClassicGame 0) Nothing)
   case mg of
     Left err -> assertFailure (from err)
     Right g -> defaultMain (tests g)


### PR DESCRIPTION
Fixes #82

Right now it only works in classic mode.  It wouldn't be too hard to
make it work with challenge mode as well, but that would require some
more careful thinking about whether every challenge is required to
have a 'base' and how we identify which robot that is, so that we run
the given file on the right robot.